### PR TITLE
Refactored JsonObject to not be InsertionMap based.

### DIFF
--- a/benchmark/src/main/scala/argonaut/benchmark/CaliperBenchmark.scala
+++ b/benchmark/src/main/scala/argonaut/benchmark/CaliperBenchmark.scala
@@ -94,9 +94,8 @@ case class CaliperScalaUtilJSONBenchmark() extends CaliperBenchmark {
 
 object ArgonautSimpleBench {
   def main(args: Array[String]) {
-    val json = Data.apachebuilds.parseOption.get
     Thread.sleep(10000)
-    (0 to 100000).foldLeft(0l){(left, right) => left + json.spaces4.length + right}
+    (0 to 3000).foldLeft(0l){(left, right) => left + Data.apachebuilds.parseOption.get.spaces4.length + right}
   }
 }
 

--- a/src/main/scala/argonaut/PrettyParams.scala
+++ b/src/main/scala/argonaut/PrettyParams.scala
@@ -69,6 +69,11 @@ sealed trait PrettyParams {
    */
   val colonRight: Int => String
 
+  /**
+   * Determines if the field ordering should be preserved.
+   */
+  val preserveOrder: Boolean
+
   private[this] final val openBraceText = "{"
   private[this] final val closeBraceText = "}"
   private[this] final val openArrayText = "["
@@ -152,7 +157,7 @@ sealed trait PrettyParams {
           }._2)
         }
         , o => {
-          rbrace(o.toList.foldLeft((true, lbrace(builder))){case ((firstElement, builder), (key, value)) =>
+          rbrace((if (preserveOrder) o.toList else o.toMap).foldLeft((true, lbrace(builder))){case ((firstElement, builder), (key, value)) =>
             val withComma = if(firstElement) builder else comma(builder)
             val updatedBuilder = trav(colon(encloseJsonString(withComma, key)), depth + 1, value)
             (false, updatedBuilder)
@@ -210,6 +215,7 @@ object PrettyParams extends PrettyParamss {
            , commaRight0: Int => String
            , colonLeft0: Int => String
            , colonRight0: Int => String
+           , preserveOrder0: Boolean
            ): PrettyParams =
     new PrettyParams {
       val lbraceLeft = lbraceLeft0
@@ -224,6 +230,7 @@ object PrettyParams extends PrettyParamss {
       val commaRight = commaRight0
       val colonLeft = colonLeft0
       val colonRight = colonRight0
+      val preserveOrder = preserveOrder0
     }
 }
 
@@ -246,6 +253,7 @@ trait PrettyParamss {
     , zeroString
     , zeroString
     , zeroString
+    , false
     )
 
   @tailrec
@@ -270,6 +278,7 @@ trait PrettyParamss {
     , n => "\n" + indent * n
     , n => " "
     , n => " "
+    , false
     )
 
   /**


### PR DESCRIPTION
The summing up of this is mostly that we get a 25% boost to printing performance by making ordering optional, at a cost of maybe 2% to parsing performance. However my intuition is that a lot of the processing done to a JsonObject like looking up fields should be a chunk faster as most operations on JsonObject should be a lot faster.

This also includes a change to PrettyParams to reflect the choice in maintaining order (which defaults to false) and a binary breaking change to JsonObject itself that gives us .toMap and .toInsertionMap, rather than the former which has the signature of the latter.
