### PR TITLE
Codecs

### DIFF
--- a/src/main/scala/argonaut/EncodeJson.scala
+++ b/src/main/scala/argonaut/EncodeJson.scala
@@ -9,11 +9,17 @@ import Json._
  *
  * @author Tony Morris
  */
-sealed trait EncodeJson[-A] {
+trait EncodeJson[-A] {
+  /**
+   * Encode the given value. Alias for `encode`.
+   */
+  def apply(a: A): Json =
+    encode(a)
+
   /**
    * Encode the given value.
    */
-  def apply(a: A): Json
+  def encode(a: A): Json
 
   /**
    * Contravariant functor.
@@ -35,7 +41,7 @@ sealed trait EncodeJson[-A] {
 object EncodeJson extends EncodeJsons {
   def apply[A](f: A => Json): EncodeJson[A] =
     new EncodeJson[A] {
-      def apply(a: A) = f(a)
+      def encode(a: A) = f(a)
     }
 }
 
@@ -43,11 +49,11 @@ trait EncodeJsons extends GeneratedEncodeJsons {
   def contrazip[A, B](e: EncodeJson[A \/ B]): (EncodeJson[A], EncodeJson[B]) =
     (EncodeJson(a => e(a.left)), EncodeJson(b => e(b.right)))
 
-  implicit def DerivedEncodeJson[A](implicit codec: CodecJson[A]): EncodeJson[A] =
-    codec.encoder
-
   implicit val IdEncodeJson: EncodeJson[Json] =
     EncodeJson(q => q)
+
+  implicit val HCursorEncodeJson: EncodeJson[HCursor] =
+    EncodeJson(q => q.focus)
 
   implicit val UnitEncodeJson: EncodeJson[Unit] =
     EncodeJson(_ => jEmptyObject)

--- a/src/test/scala/argonaut/CodecSpecification.scala
+++ b/src/test/scala/argonaut/CodecSpecification.scala
@@ -12,11 +12,34 @@ import org.specs2.matcher._
 import scalaz._
 import Scalaz._
 
+
 object CodecSpecification extends Specification with ScalaCheck {
-  def encodedecode[A: DecodeJson : EncodeJson : Arbitrary : Equal] =
-    prop((a: A) =>
-      implicitly[DecodeJson[A]].apply(implicitly[EncodeJson[A]].apply(a).hcursor).value exists (_ === a)
-    )
+  def encodedecode[A: CodecJson : Arbitrary : Equal] =
+    forAll(implicitly[CodecJson[A]].codecLaw.encodedecode _)
+
+  def is = "Codec" ^
+    "Unit encode/decode" ! encodedecode[Unit] ^
+    "List[String] encode/decode" ! encodedecode[List[String]] ^
+    "Vector[String] encode/decode" ! encodedecode[Vector[String]] ^
+    "Stream[String] encode/decode" ! encodedecode[Stream[String]] ^
+    "String encode/decode" ! encodedecode[String] ^
+    "Double encode/decode" ! encodedecode[Double] ^
+    "Float encode/decode" ! encodedecode[Float] ^
+    "Int encode/decode" ! encodedecode[Int] ^
+    "Long encode/decode" ! encodedecode[Long] ^
+    "Boolean encode/decode" ! encodedecode[Boolean] ^
+    "Char encode/decode" ! encodedecode[Char] ^
+    "Option[String] encode/decode" ! encodedecode[Option[String]] ^
+    "Either[String, Int] encode/decode" ! encodedecode[Either[String, Int]] ^
+    "String \\/ Int encode/decode" ! encodedecode[String \/ Int] ^
+    "Map[String, Int] encode/decode" ! encodedecode[Map[String, Int]] ^
+    "Set[String] encode/decode" ! encodedecode[Set[String]] ^
+    "Tuple2[String, Int] encode/decode" ! encodedecode[Tuple2[String, Int]] ^
+    "Tuple3[String, Int, Boolean] encode/decode" ! encodedecode[Tuple3[String, Int, Boolean]] ^
+    "Tuple4[String, Int, Boolean, Long] encode/decode" ! encodedecode[Tuple4[String, Int, Boolean, Long]] ^
+    "22 field class with codec" ! { import CodecInstances._; encodedecode[TestClass] } ^
+    "22 field class with codec derived" ! { import EncodeDecodeInstances._; encodedecode[TestClass] } ^ end
+
 
   case class TestClass(a: Int, b: Int, c: String, d: Int, e: Int, f: String, g: Int, h: Int, i: String, j: Int, k: Int, l: String, m: Int, n: Int, o: String, p: Int, q: Int, r: String, s: Int, t: Int, u: String, v: Boolean)
 
@@ -49,41 +72,13 @@ object CodecSpecification extends Specification with ScalaCheck {
 
   implicit val showTestClass: Show[TestClass] = Show.showFromToString
 
-  implicit val testClassEncode: EncodeJson[TestClass] = EncodeJson.jencode22L((x: TestClass) => (x.a, x.b, x.c, x.d, x.e, x.f, x.g, x.h, x.i, x.j, x.k, x.l, x.m, x.n, x.o, x.p, x.q, x.r, x.s, x.t, x.u, x.v))("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v")
+  object EncodeDecodeInstances {
+    implicit val testClassEncode: EncodeJson[TestClass] = EncodeJson.jencode22L((x: TestClass) => (x.a, x.b, x.c, x.d, x.e, x.f, x.g, x.h, x.i, x.j, x.k, x.l, x.m, x.n, x.o, x.p, x.q, x.r, x.s, x.t, x.u, x.v))("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v")
 
-  implicit val testClassDecode: DecodeJson[TestClass] = DecodeJson.jdecode22L(TestClass.apply)("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v")
-
-  def encodeL22DecodeL22(): Prop = {
-    prop{testClass: TestClass =>
-      val encodedValue = testClass.jencode
-      ("encoded value = " + encodedValue.shows) |: {
-        val decodeResult = encodedValue.jdecode[TestClass]
-        ("decode result = " + decodeResult.shows) |: {
-          decodeResult === DecodeResult.ok(testClass)
-        }
-      }
-    }
+    implicit val testClassDecode: DecodeJson[TestClass] = DecodeJson.jdecode22L(TestClass.apply)("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v")
   }
 
-  def is = "Codec" ^
-    "Unit encode/decode" ! encodedecode[Unit] ^
-    "List[String] encode/decode" ! encodedecode[List[String]] ^
-    "Vector[String] encode/decode" ! encodedecode[Vector[String]] ^
-    "Stream[String] encode/decode" ! encodedecode[Stream[String]] ^
-    "String encode/decode" ! encodedecode[String] ^
-    "Double encode/decode" ! encodedecode[Double] ^
-    "Float encode/decode" ! encodedecode[Float] ^
-    "Int encode/decode" ! encodedecode[Int] ^
-    "Long encode/decode" ! encodedecode[Long] ^
-    "Boolean encode/decode" ! encodedecode[Boolean] ^
-    "Char encode/decode" ! encodedecode[Char] ^
-    "Option[String] encode/decode" ! encodedecode[Option[String]] ^
-    "Either[String, Int] encode/decode" ! encodedecode[Either[String, Int]] ^
-    "String \\/ Int encode/decode" ! encodedecode[String \/ Int] ^
-    "Map[String, Int] encode/decode" ! encodedecode[Map[String, Int]] ^
-    "Set[String] encode/decode" ! encodedecode[Set[String]] ^
-    "Tuple2[String, Int] encode/decode" ! encodedecode[Tuple2[String, Int]] ^
-    "Tuple3[String, Int, Boolean] encode/decode" ! encodedecode[Tuple3[String, Int, Boolean]] ^
-    "Tuple4[String, Int, Boolean, Long] encode/decode" ! encodedecode[Tuple4[String, Int, Boolean, Long]] ^
-    "22 field class encode/decode" ! encodeL22DecodeL22 ^ end
+  object CodecInstances {
+    implicit val testClassEncode: CodecJson[TestClass] = CodecJson.casecodec22(TestClass.apply, TestClass.unapply)("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v")
+  }
 }


### PR DESCRIPTION
Fixes #18.
Fixes #41. (By exporting law on CodecJson)

After this commit there are some nice conveniences for
declaring Encode and Decode pairs.

For example:

  case class Fred(name: String, age: Int)

  // safe

  val codec = codec2(Fred.apply, fred => (fred.name, fred.age))(name, age)

  // or utilizing generated unapply (partial function, but not really for case classes)

  val codec = casecodec2(Fred.apply, Fred.unapply)(name, age)
