### PR TITLE
Special treatment for NaN and Infinity as per RFC-4627.

### DIFF
--- a/src/main/scala/argonaut/Json.scala
+++ b/src/main/scala/argonaut/Json.scala
@@ -553,7 +553,8 @@ trait Jsons {
    * Construct a JSON value that is a number.
    */
   val jNumber: JsonNumber => Json =
-    JNumber(_)
+    (number: JsonNumber) =>
+      (number.isNaN || number.isInfinity) ? jNull | JNumber(number)
 
   /**
    * Construct a JSON value that is a string.


### PR DESCRIPTION
[RFC](http://tools.ietf.org/html/rfc4627#page-3) specifically states that `NaN` and `Infinity` values are forbidden.

> Numeric values that cannot be represented as sequences of digits
> (such as Infinity and NaN) are not permitted.
