### PR TITLE
Fix ACursor.get to decode failures as Option

### DIFF
--- a/src/main/scala/argonaut/ACursor.scala
+++ b/src/main/scala/argonaut/ACursor.scala
@@ -37,10 +37,7 @@ case class ACursor(either: HCursor \/ HCursor) {
    * Attempts to move down onto a field `name` and decode the focus.
    */
   def get[A](name: String)(implicit e: DecodeJson[A]): DecodeResult[A] =
-    either match {
-      case -\/(invalid) => DecodeResult.fail("Attempt to decode value on failed cursor.", invalid.history)
-      case \/-(valid) => valid.get[A](name)
-    }
+    downField(name).as[A]
 
   def succeeded: Boolean =
     hcursor.isDefined

--- a/src/test/scala/argonaut/CodecOptionSpecification.scala
+++ b/src/test/scala/argonaut/CodecOptionSpecification.scala
@@ -17,6 +17,22 @@ object CodecOptionSpecification extends Specification with ScalaCheck {
     "handles missing field" ! { jEmptyObject.as[Thing] must_== DecodeResult.ok(Thing(None)) } ^
     "handles null field" ! { Json.obj("value" := jNull).as[Thing] must_== DecodeResult.ok(Thing(None)) } ^
     "handles set field" ! prop { (value: String) => Json.obj("value" := value).as[Thing] must_== DecodeResult.ok(Thing(Some(value))) } ^
+    "handles missing nested fields using as[T]" ! prop { (value: String) =>
+      val third = Json.obj("first" := jEmptyObject)
+        .hcursor
+        .downField("first")
+        .downField("second")
+        .downField("third")
+        .as[Option[String]]
+      third must_== DecodeResult.ok(None)
+    } ^
+    "handles missing nested fields using get[T]" ! prop { (value: String) =>
+      val third = Json.obj("first" := jEmptyObject)
+        .hcursor
+        .downField("first")
+        .downField("second")
+        .get[Option[String]]("third")
+      third must_== DecodeResult.ok(None)
+    } ^
     end
-
 }


### PR DESCRIPTION
The following two ways of decoding a field's value were not equivalent:
1. `downField(a).downField(b).downField(c).as[Option[A]]`
2. `downField(a).downField(b).get[Option[A]](c)`

More details in the tests.
