### PR TITLE
Allow DecodeJson ||| to combine as supertype.

### DIFF
--- a/src/main/scala/argonaut/DecodeJson.scala
+++ b/src/main/scala/argonaut/DecodeJson.scala
@@ -84,9 +84,9 @@ trait DecodeJson[A] {
   /**
    * Choose the first succeeding decoder.
    */
-  def |||(x: => DecodeJson[A]): DecodeJson[A] =
-    DecodeJson(c => {
-      val q = apply(c)
+  def |||[AA >: A](x: => DecodeJson[AA]): DecodeJson[AA] =
+    DecodeJson[AA](c => {
+      val q = apply(c).map(a => a: AA)
       q.result.fold(_ => x(c), _ => q)
     })
 


### PR DESCRIPTION
Allow ||| to return a DecodeJson of the common super type of the 2 arguments (DecodeResult already does this). This was motivated by this pattern:

```
sealed trait AB
case class A(a: A) extends AB
case class B(b: B) extends AB
```

   val acodec: CodecJson[A] = casecodec1(A.apply, A.unapply)("a")
   val bcodec: CodecJson[B] = casecodec1(B.apply, B.unapply)("b")
   implicit val abdecoder: DecodeJson[AB] = acodec ||| bcodec

The alternative is to use the ||| on DecodeResult.
