### PR TITLE
upgrade version of lift-json so the benchmarks compile

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -19,7 +19,7 @@ object build extends Build {
   val scalacheck                 = "org.scalacheck"               %% "scalacheck"                % "1.11.5"                 % "test"
   val specs2Scalacheck           = "org.specs2"                   %% "specs2-scalacheck"         % "2.4"                    % "test"
   val caliper                    = "com.google.caliper"           %  "caliper"                   % "0.5-rc1"
-  val liftjson                   = "net.liftweb"                  %  "lift-json_2.9.2"           % "2.5-M3"
+  val liftjson                   = "net.liftweb"                  %% "lift-json"                 % "2.6-RC1"
   val jackson                    = "com.fasterxml.jackson.core"   %  "jackson-core"              % "2.4.1.1"
   val monocle                    = "com.github.julien-truffaut"   %% "monocle-core"              % "0.5.0"
 


### PR DESCRIPTION
updating the lift-json version as the previous causes compile errors
