### PR TITLE
A cleaned-up and squashed version of shapeless derived codecs.

### DIFF
--- a/project/ScalaSettings.scala
+++ b/project/ScalaSettings.scala
@@ -10,5 +10,7 @@ object ScalaSettings {
   , crossScalaVersions := Seq("2.10.4", "2.11.2")
   , fork in test := true
   , scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:_", "-Xlint")
+  // https://gist.github.com/djspiewak/976cd8ac65e20e136f05
+  , unmanagedSourceDirectories in Compile += (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"
   )
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -17,27 +17,43 @@ object build extends Build {
   val scalaz                     = "org.scalaz"                   %% "scalaz-core"               % scalazVersion
   val scalazScalaCheckBinding    = "org.scalaz"                   %% "scalaz-scalacheck-binding" % scalazVersion            % "test" exclude("org.scalacheck", "scalacheck")
   val scalacheck                 = "org.scalacheck"               %% "scalacheck"                % "1.11.5"                 % "test"
-  val specs2Scalacheck           = "org.specs2"                   %% "specs2-scalacheck"         % "2.4"                    % "test"
+  val specs2Scalacheck           = "org.specs2"                   %% "specs2-scalacheck"         % "2.4"                    % "test" excludeAll ExclusionRule(organization = "org.scalamacros")
   val caliper                    = "com.google.caliper"           %  "caliper"                   % "0.5-rc1"
   val liftjson                   = "net.liftweb"                  %% "lift-json"                 % "2.6-RC1"
   val jackson                    = "com.fasterxml.jackson.core"   %  "jackson-core"              % "2.4.1.1"
   val monocle                    = "com.github.julien-truffaut"   %% "monocle-core"              % "0.5.0"
+  def shapeless(v: String)   =
+    if (v.contains("2.10"))        "com.chuusai"                  %  s"shapeless_${v}"           % "2.0.0"
+    else                           "com.chuusai"                  %% s"shapeless"                % "2.0.0"
+
+  def reflect(v: String)         =
+                               Seq("org.scala-lang"               %  "scala-compiler"            % v,
+                                   "org.scala-lang"               %  "scala-reflect"             % v) ++
+    (if (v.contains("2.10"))   Seq("org.scalamacros"              %% "quasiquotes"               % "2.0.0") else Seq())
+
 
   val argonaut = Project(
     id = "argonaut"
   , base = file(".")
-  , settings = base ++ 
-    ReplSettings.all ++ 
-    releaseSettings ++ 
-    PublishSettings.all ++ 
-    InfoSettings.all ++ 
+  , settings = base ++
+    ReplSettings.all ++
+    releaseSettings ++
+    PublishSettings.all ++
+    InfoSettings.all ++
     net.virtualvoid.sbt.graph.Plugin.graphSettings ++ Seq[Sett](
       name := "argonaut"
     , (sourceGenerators in Compile) <+= (sourceManaged in Compile) map Boilerplate.gen
     , resolvers += Resolver.sonatypeRepo("releases")
     , resolvers += Resolver.sonatypeRepo("snapshots")
     , autoScalaLibrary := false
-    , libraryDependencies ++= Seq(scalaz, scalazScalaCheckBinding, monocle, scalacheck, specs2Scalacheck)
+    , libraryDependencies ++= Seq(
+        scalaz
+      , scalazScalaCheckBinding
+      , monocle
+      , scalacheck
+      , specs2Scalacheck
+      , shapeless(scalaVersion.value)
+      ) ++ reflect(scalaVersion.value)
      /* no mima until 6.1.0 release */
     , previousArtifact := None
 /*    , binaryIssueFilters ++= {

--- a/src/main/scala-2.10/argonaut.internal/MacrosCompat.scala
+++ b/src/main/scala-2.10/argonaut.internal/MacrosCompat.scala
@@ -1,0 +1,6 @@
+package argonaut.internal
+
+trait MacrosCompat {
+  import language.experimental.macros
+  type Context = scala.reflect.macros.Context
+}

--- a/src/main/scala-2.11/argonaut.internal/MacrosCompat.scala
+++ b/src/main/scala-2.11/argonaut.internal/MacrosCompat.scala
@@ -1,0 +1,5 @@
+package argonaut.internal
+
+trait MacrosCompat {
+  type Context = scala.reflect.macros.blackbox.Context
+}

--- a/src/test/scala/argonaut/DecodeJsonSpecification.scala
+++ b/src/test/scala/argonaut/DecodeJsonSpecification.scala
@@ -1,0 +1,93 @@
+package argonaut
+
+import scalaz._, Scalaz._
+import shapeless._
+import org.scalacheck._, Arbitrary._, Prop._
+import org.specs2._, org.specs2.specification._
+
+object DecodeJsonSpecification extends Specification with ScalaCheck { def is = s2"""
+
+DecodeJson Witness Compilation
+------------------------------
+
+  Witness basics                        ${ok}
+  Witness tuples                        ${ok}
+  Witness auto                          ${ok}
+  Witness derived                       ${ok}
+
+DecodeJson Auto Derivation
+--------------------------
+
+  Product-types correspond              ${auto.products}
+  Sum-types correspond                  NOT COMPILING-- auto.sums
+
+"""
+
+  object primitives {
+    DecodeJson.of[String]
+    DecodeJson.of[Int]
+    DecodeJson.of[Boolean]
+    DecodeJson.of[Long]
+    DecodeJson.of[Double]
+    DecodeJson.of[Short]
+    DecodeJson.of[Option[Int]]
+    DecodeJson.of[Option[String]]
+  }
+
+  object tuples {
+    DecodeJson.of[(String, Int)]
+    DecodeJson.of[(String, Int, Boolean)]
+    DecodeJson.of[(String, Int, Boolean, Long)]
+    DecodeJson.of[(String, Int, Boolean, Long, Double)]
+  }
+
+
+
+  object auto {
+    import shapeless._
+    import DecodeJson.auto._
+    import StringWrap._
+
+    case class Person(name: String, age: Int)
+
+    implicit def PersonArbitrary: Arbitrary[Person] = Arbitrary(for {
+      n <- arbitrary[String]
+      a <- arbitrary[Int]
+    } yield Person(n, a))
+
+    DecodeJson.of[Person]
+
+    def products = prop((p: Person) =>
+      Json("Person" := Json("name" := p.name, "age" := p.age)).as[Person].toOption must_== Some(p))
+
+
+    /* FIX this should work, but doesn't --
+
+    sealed trait Shape
+    case class Circle(radius: Int) extends Shape
+    case class Square(side: Int) extends Shape
+
+    implicit def ShapeArbitrary: Arbitrary[Shape] = Arbitrary(Gen.oneOf(
+      arbitrary[Int].map(Circle.apply)
+    , arbitrary[Int].map(Square.apply)
+    ))
+
+    def sums = prop((s: Shape) =>
+      (s match {
+        case Circle(radius) => Json("Circle" := Json("radius" := radius))
+        case Square(side) => Json("Square" := Json("side" := side))
+      }).as[Shape].toOption must_== Some(s))
+
+    */
+  }
+
+  object derived {
+    case class Person(name: String, age: Int)
+
+    implicit def PersonDecodeJson: DecodeJson[Person] =
+      DecodeJson.derive[Person]
+
+    DecodeJson.of[Person]
+  }
+
+}

--- a/src/test/scala/argonaut/EncodeJsonSpecification.scala
+++ b/src/test/scala/argonaut/EncodeJsonSpecification.scala
@@ -1,0 +1,91 @@
+package argonaut
+
+import scalaz._, Scalaz._
+import shapeless._
+import org.scalacheck._, Arbitrary._, Prop._
+import org.specs2._, org.specs2.specification._
+
+object EncodeJsonSpecification extends Specification with ScalaCheck { def is = s2"""
+
+EncodeJson Witness Compilation
+------------------------------
+
+  Witness basics                        ${ok}
+  Witness tuples                        ${ok}
+  Witness auto                          ${ok}
+  Witness derived                       ${ok}
+
+EncodeJson Auto Derivation
+--------------------------
+
+  Product-types correspond              ${auto.products}
+  Sum-types correspond                  NOT COMPILING-- auto.sums
+
+"""
+
+  object primitives {
+    EncodeJson.of[String]
+    EncodeJson.of[Int]
+    EncodeJson.of[Boolean]
+    EncodeJson.of[Long]
+    EncodeJson.of[Double]
+    EncodeJson.of[Short]
+    EncodeJson.of[Option[Int]]
+    EncodeJson.of[Option[String]]
+  }
+
+  object tuples {
+    EncodeJson.of[(String, Int)]
+    EncodeJson.of[(String, Int, Boolean)]
+    EncodeJson.of[(String, Int, Boolean, Long)]
+    EncodeJson.of[(String, Int, Boolean, Long, Double)]
+  }
+
+  object auto {
+    import shapeless._
+    import EncodeJson.auto._
+    import StringWrap._
+    import JsonIdentity._
+
+    case class Person(name: String, age: Int)
+
+    implicit def PersonArbitrary: Arbitrary[Person] = Arbitrary(for {
+      n <- arbitrary[String]
+      a <- arbitrary[Int]
+    } yield Person(n, a))
+
+    EncodeJson.of[Person]
+
+    def products = prop((p: Person) =>
+      p.asJson must_== Json("Person" := Json("name" := p.name, "age" := p.age)))
+
+    /* FIX this should work, but doesn't --
+
+    sealed trait Shape
+    case class Circle(radius: Int) extends Shape
+    case class Square(side: Int) extends Shape
+
+    implicit def ShapeArbitrary: Arbitrary[Shape] = Arbitrary(Gen.oneOf(
+      arbitrary[Int].map(Circle.apply)
+    , arbitrary[Int].map(Square.apply)
+    ))
+
+    EncodeJson.of[Shape]
+
+    def sums = prop((s: Shape) =>
+      s.asJson(x) must_== (s match {
+        case Circle(radius) => Json("Circle" := Json("radius" := radius))
+        case Square(side) => Json("Square" := Json("side" := side))
+      }))  */
+  }
+
+  object derived {
+    case class Person(name: String, age: Int)
+
+    implicit def PersonEncodeJson: EncodeJson[Person] =
+      EncodeJson.derive[Person]
+
+    EncodeJson.of[Person]
+  }
+
+}


### PR DESCRIPTION
This is all the work of @maxpow4h and @travisbrown, see #108.

Fixes #108.
Fixes #109.

This still has some issues around how the types are
encoded and sum types, but it puts things in an
easier state for someone else to help with.
