### PR TITLE
add filter and withFilter alias on DecodeResult

### DIFF
--- a/src/main/scala/argonaut/DecodeResult.scala
+++ b/src/main/scala/argonaut/DecodeResult.scala
@@ -20,6 +20,12 @@ case class DecodeResult[A](result:  (String, CursorHistory) \/ A) {
   def flatMap[B](f: A => DecodeResult[B]): DecodeResult[B] =
     DecodeResult(result flatMap (f(_).result))
 
+  def filter(f: A => Boolean) =
+    DecodeResult(result filter f)
+
+  def withFilter(f: A => Boolean) =
+    filter(f)
+
   def message: Option[String] =
     failure map (_._1)
 

--- a/src/test/scala/argonaut/example/CodecExample.scala
+++ b/src/test/scala/argonaut/example/CodecExample.scala
@@ -35,5 +35,21 @@ object CodecExample extends Specification {
 
     encodeDecode("""{"name":"Fred","age":40}""")
   }
+  Object codec with filtering ${
+    implicit val DecodePersonOver30: DecodeJson[Person] =
+      DecodeJson(c =>
+        for {
+          name <- (c --\ "name").as[String]
+          age <- (c --\ "age").as[Int] if age > 30
+        } yield Person(name, age)
+      )
+
+    implicit val EncodePerson: EncodeJson[Person] =
+      jencode2L((p: Person) => (p.name, p.age))("name", "age")
+
+    encodeDecode("""{"name":"Fred","age":40}""")
+    
+    """{"name":"Fred","age":20}""".decodeOption[Person] must beNone
+  }
   """
 }


### PR DESCRIPTION
Original motivation was wanting a slightly more humane way of filtering json that parsed successfully, yet may not represent a valid value. For example, if a string value is used to represent case objects and we need to make sure this value maps to one of them, pattern guards are convenient means to do so.
