### PR TITLE
Enabled sum-types tests

### DIFF
--- a/src/test/scala/argonaut/DecodeJsonSpecification.scala
+++ b/src/test/scala/argonaut/DecodeJsonSpecification.scala
@@ -5,6 +5,12 @@ import shapeless._
 import org.scalacheck._, Arbitrary._, Prop._
 import org.specs2._, org.specs2.specification._
 
+// Defining these below (close to ShapeArbitrary say) makes the DecodeJson derivation fail
+// Same thing for EncodeJson
+sealed trait Shape
+case class Circle(radius: Int) extends Shape
+case class Square(side: Int) extends Shape
+
 object DecodeJsonSpecification extends Specification with ScalaCheck { def is = s2"""
 
 DecodeJson Witness Compilation
@@ -19,7 +25,7 @@ DecodeJson Auto Derivation
 --------------------------
 
   Product-types correspond              ${auto.products}
-  Sum-types correspond                  NOT COMPILING-- auto.sums
+  Sum-types correspond                  ${auto.sums}
 
 """
 
@@ -61,12 +67,6 @@ DecodeJson Auto Derivation
       Json("Person" := Json("name" := p.name, "age" := p.age)).as[Person].toOption must_== Some(p))
 
 
-    /* FIX this should work, but doesn't --
-
-    sealed trait Shape
-    case class Circle(radius: Int) extends Shape
-    case class Square(side: Int) extends Shape
-
     implicit def ShapeArbitrary: Arbitrary[Shape] = Arbitrary(Gen.oneOf(
       arbitrary[Int].map(Circle.apply)
     , arbitrary[Int].map(Square.apply)
@@ -77,8 +77,6 @@ DecodeJson Auto Derivation
         case Circle(radius) => Json("Circle" := Json("radius" := radius))
         case Square(side) => Json("Square" := Json("side" := side))
       }).as[Shape].toOption must_== Some(s))
-
-    */
   }
 
   object derived {

--- a/src/test/scala/argonaut/EncodeJsonSpecification.scala
+++ b/src/test/scala/argonaut/EncodeJsonSpecification.scala
@@ -19,7 +19,7 @@ EncodeJson Auto Derivation
 --------------------------
 
   Product-types correspond              ${auto.products}
-  Sum-types correspond                  NOT COMPILING-- auto.sums
+  Sum-types correspond                  ${auto.sums}
 
 """
 
@@ -59,12 +59,6 @@ EncodeJson Auto Derivation
     def products = prop((p: Person) =>
       p.asJson must_== Json("Person" := Json("name" := p.name, "age" := p.age)))
 
-    /* FIX this should work, but doesn't --
-
-    sealed trait Shape
-    case class Circle(radius: Int) extends Shape
-    case class Square(side: Int) extends Shape
-
     implicit def ShapeArbitrary: Arbitrary[Shape] = Arbitrary(Gen.oneOf(
       arbitrary[Int].map(Circle.apply)
     , arbitrary[Int].map(Square.apply)
@@ -73,10 +67,10 @@ EncodeJson Auto Derivation
     EncodeJson.of[Shape]
 
     def sums = prop((s: Shape) =>
-      s.asJson(x) must_== (s match {
+      s.asJson must_== (s match {
         case Circle(radius) => Json("Circle" := Json("radius" := radius))
         case Square(side) => Json("Square" := Json("side" := side))
-      }))  */
+      }))
   }
 
   object derived {


### PR DESCRIPTION
Contrary to appearances, auto codec derivation seems to work for sum types.

But to make the tests work, I had to move the definitions of the sum type outside the test object. This may be loosely related to [this issue](https://github.com/milessabin/shapeless/issues/212) (although the latter's fix doesn't solve the former).

Another possible workaround would be to disable auto codec derivation for sum types, by deriving shapeless' `LabelledProductTypeClass` instead of `LabelledTypeClass`. And because of [this other possible issue](https://github.com/milessabin/shapeless/issues/257), this would solve the second point of https://github.com/argonaut-io/argonaut/issues/129 at the same time.
