### PR TITLE
Add JsonNumber constructor for JSON.

### DIFF
--- a/src/main/scala/argonaut/Json.scala
+++ b/src/main/scala/argonaut/Json.scala
@@ -700,6 +700,11 @@ trait Jsons {
 
   /**
    * Construct a JSON value that is a number.
+   */
+  def jNumber(n: JsonNumber): Json = JNumber(n)
+
+  /**
+   * Construct a JSON value that is a number.
    *
    * Note: NaN, +Infinity and -Infinity are not valid json.
    */


### PR DESCRIPTION
Adds the missing constructor that takes a JsonNumber and returns a Json. Needed to match the fold which has a JsonNumber case.
