### PR TITLE
upgrade specs2 and scalacheck

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -18,14 +18,14 @@ object build extends Build {
   val monocleVersion             = "1.1.0"
   val scalaz                     = "org.scalaz"                   %% "scalaz-core"               % scalazVersion
   val scalazScalaCheckBinding    = "org.scalaz"                   %% "scalaz-scalacheck-binding" % scalazVersion            % "test" exclude("org.scalacheck", "scalacheck")
-  val scalacheck                 = "org.scalacheck"               %% "scalacheck"                % "1.11.5"                 % "test"
-  val specs2Scalacheck           = "org.specs2"                   %% "specs2-scalacheck"         % "2.4"                    % "test" excludeAll ExclusionRule(organization = "org.scalamacros")
+  val scalacheck                 = "org.scalacheck"               %% "scalacheck"                % "1.12.2"                 % "test"
+  val specs2Scalacheck           = "org.specs2"                   %% "specs2-scalacheck"         % "3.3.1"                  % "test"
   val caliper                    = "com.google.caliper"           %  "caliper"                   % "0.5-rc1"
   val liftjson                   = "net.liftweb"                  %% "lift-json"                 % "2.6-RC1"
   val jackson                    = "com.fasterxml.jackson.core"   %  "jackson-core"              % "2.4.1.1"
   val monocle                    = "com.github.julien-truffaut"   %% "monocle-core"              % monocleVersion
   val monocleMacro               = "com.github.julien-truffaut"   %% "monocle-macro"             % monocleVersion
-  val monocleLaw                 = "com.github.julien-truffaut"   %% "monocle-law"               % monocleVersion           % "test" excludeAll ExclusionRule(organization = "org.specs2")
+  val monocleLaw                 = "com.github.julien-truffaut"   %% "monocle-law"               % monocleVersion           % "test"
 
   def reflect(v: String)         =
                                     Seq("org.scala-lang" % "scala-reflect"  % v) ++

--- a/src/test/scala/argonaut/JsonFilesSpecification.scala
+++ b/src/test/scala/argonaut/JsonFilesSpecification.scala
@@ -1,12 +1,11 @@
 package argonaut
 
-import Data._
-import org.scalacheck._
-import org.specs2._, org.specs2.specification._, execute.Result
-import org.specs2.matcher._
-import scalaz._, Scalaz._
-import Argonaut._
 import java.io.File
+
+import argonaut.Argonaut._
+import org.scalacheck.Prop._
+import org.scalacheck._
+import org.specs2._
 
 object JsonFilesSpecification extends Specification with ScalaCheck {
   def find = new File(getClass.getResource("/data").toURI).listFiles.toList
@@ -16,10 +15,9 @@ object JsonFilesSpecification extends Specification with ScalaCheck {
   implicit def JsonFileArbitrary: Arbitrary[JsonFile] =
     Arbitrary(Gen.oneOf(find.map(JsonFile)))
 
-  def is = s2""" Predefined files can print and get same result" ! ${propNoShrink(test)} """
+  def is = s2""" Predefined files can print and get same result" ! $test """
 
-  val test: JsonFile => Result =
-    jsonfile => {
+  val test = forAllNoShrink { jsonfile: JsonFile =>
       val string = scala.io.Source.fromFile(jsonfile.file).mkString
       val parsed = string.parseOption
       val json = parsed.getOrElse(sys.error("could not parse json file [" + jsonfile + "]"))


### PR DESCRIPTION
I am getting another error but I think it goes it the right direction.

```scala
[error] 
[error] java.lang.NoSuchMethodError: org.scalacheck.Gen$.value(Ljava/lang/Object;)Lorg/scalacheck/Gen;
[error] 
[error] STACKTRACE
[error]   scalaz.scalacheck.ScalaCheckBinding$$anon$1$$anonfun$point$1$$anonfun$apply$2.apply(ScalaCheckBinding.scala:13)
[error]   scalaz.scalacheck.ScalaCheckBinding$$anon$1$$anonfun$point$1$$anonfun$apply$2.apply(ScalaCheckBinding.scala:13)

```