### PR TITLE
Enable automatic Scaladoc linking

### DIFF
--- a/project/PublishSettings.scala
+++ b/project/PublishSettings.scala
@@ -13,6 +13,8 @@ object PublishSettings {
   , pomIncludeRepository := { _ => false }
   , licenses := Seq("BSD-3-Clause" -> url("http://www.opensource.org/licenses/BSD-3-Clause"))
   , homepage := Some(url("http://argonaut.io"))
+  , autoAPIMappings := true
+  , apiURL := Some(url("http://argonaut.io/scaladocs/"))
   , useGpg := true
   )
 


### PR DESCRIPTION
These additions add a bit of metadata to the pom that allows other projects that depend on Argonaut to have their API docs automatically linked to Argonaut's. We'd like to have this for [Finch](https://github.com/finagle/finch) now that we're [making Argonaut](https://github.com/finagle/finch/issues/233) the preferred JSON library.

The only consequences for Argonaut are a few extra lines in the published pom and links in the Argonaut API docs to classes in the standard library (and any other dependencies that publish this metadata, which I think at the moment isn't any of them).