### PR TITLE
Add support for encoding/decoding Bytes

### DIFF
--- a/src/main/scala/argonaut/DecodeJson.scala
+++ b/src/main/scala/argonaut/DecodeJson.scala
@@ -221,6 +221,12 @@ trait DecodeJsons extends GeneratedDecodeJsons {
       (x.string flatMap (s => tryTo(s.toShort)))), "Short")
   }
 
+  implicit def ByteDecodeJson: DecodeJson[Byte] = {
+    optionDecoder(x =>
+      (x.number map (_.truncateToByte)).orElse(
+      (x.string flatMap (s => tryTo(s.toByte)))), "Byte")
+  }
+
   implicit def BigIntDecodeJson: DecodeJson[BigInt] = {
     optionDecoder(x =>
       (x.number map (_.truncateToBigInt)).orElse(
@@ -259,6 +265,10 @@ trait DecodeJsons extends GeneratedDecodeJsons {
 
   implicit def JShortDecodeJson: DecodeJson[java.lang.Short] = {
     optionDecoder(_.number flatMap (s => tryTo(s.truncateToShort)), "java.lang.Short")
+  }
+
+  implicit def JByteDecodeJson: DecodeJson[java.lang.Byte] = {
+    optionDecoder(_.number flatMap (s => tryTo(s.truncateToByte)), "java.lang.Byte")
   }
 
   implicit def JBooleanDecodeJson: DecodeJson[java.lang.Boolean] = {

--- a/src/main/scala/argonaut/EncodeJson.scala
+++ b/src/main/scala/argonaut/EncodeJson.scala
@@ -89,6 +89,9 @@ trait EncodeJsons extends GeneratedEncodeJsons {
   implicit val ShortEncodeJson: EncodeJson[Short] =
     EncodeJson(a => JsonLong(a.toLong).asJsonOrNull)
 
+  implicit val ByteEncodeJson: EncodeJson[Byte] =
+    EncodeJson(a => JsonLong(a.toLong).asJsonOrNull)
+
   implicit val BigDecimalEncodeJson: EncodeJson[BigDecimal] =
     EncodeJson(a => JsonBigDecimal(a).asJsonOrNull)
 
@@ -115,6 +118,9 @@ trait EncodeJsons extends GeneratedEncodeJsons {
 
   implicit val JShortEncodeJson: EncodeJson[java.lang.Short] =
     EncodeJson(a => JsonLong(a.shortValue.toLong).asJsonOrNull)
+
+  implicit val JByteEncodeJson: EncodeJson[java.lang.Byte] =
+    EncodeJson(a => JsonLong(a.shortValue.toByte).asJsonOrNull)
 
   implicit val JBooleanEncodeJson: EncodeJson[java.lang.Boolean] =
     EncodeJson(a => jBool(a.booleanValue))

--- a/src/test/scala/argonaut/DecodeJsonSpecification.scala
+++ b/src/test/scala/argonaut/DecodeJsonSpecification.scala
@@ -22,6 +22,7 @@ object DecodeJsonSpecification extends Specification with ScalaCheck { def is = 
     DecodeJson.of[Long]
     DecodeJson.of[Double]
     DecodeJson.of[Short]
+    DecodeJson.of[Byte]
     DecodeJson.of[Option[Int]]
     DecodeJson.of[Option[String]]
   }

--- a/src/test/scala/argonaut/EncodeJsonSpecification.scala
+++ b/src/test/scala/argonaut/EncodeJsonSpecification.scala
@@ -22,6 +22,7 @@ object EncodeJsonSpecification extends Specification with ScalaCheck { def is = 
     EncodeJson.of[Long]
     EncodeJson.of[Double]
     EncodeJson.of[Short]
+    EncodeJson.of[Byte]
     EncodeJson.of[Option[Int]]
     EncodeJson.of[Option[String]]
   }


### PR DESCRIPTION
I noticed the lack of missing instances for DecodeJson/EncodeJson for Byte, so I added them

Best,
Markus