### PR TITLE
Fix errors in HCursor

### DIFF
--- a/src/main/scala/argonaut/CursorOpElement.scala
+++ b/src/main/scala/argonaut/CursorOpElement.scala
@@ -64,6 +64,8 @@ case object CursorOpDeleteGoLast extends CursorOpElement
 case class CursorOpDeleteGoField(f: JsonField) extends CursorOpElement
 case object CursorOpDeleteLefts extends CursorOpElement
 case object CursorOpDeleteRights extends CursorOpElement
+case class CursorOpSetLefts(x: List[Json]) extends CursorOpElement
+case class CursorOpSetRights(x: List[Json]) extends CursorOpElement
 
 object CursorOpElement extends CursorOpElements
 
@@ -95,6 +97,8 @@ trait CursorOpElements {
           case CursorOpDeleteGoField(f) => "!--(" + f + ")"
           case CursorOpDeleteLefts => "!<"
           case CursorOpDeleteRights => ">!"
+          case CursorOpSetLefts(_) => "!...<"
+          case CursorOpSetRights(_) => ">...!"
         }
 
       def equal(e1: CursorOpElement, e2: CursorOpElement) =

--- a/src/main/scala/argonaut/HCursor.scala
+++ b/src/main/scala/argonaut/HCursor.scala
@@ -92,11 +92,11 @@ case class HCursor(cursor: Cursor, history: CursorHistory) {
 
   /** Move the cursor to the first in a JSON array. */
   def first: ACursor =
-    history.acursorElement(Store(_.left, cursor), CursorOpFirst)
+    history.acursorElement(Store(_.first, cursor), CursorOpFirst)
 
   /** Move the cursor to the last in a JSON array. */
   def last: ACursor =
-    history.acursorElement(Store(_.left, cursor), CursorOpLast)
+    history.acursorElement(Store(_.last, cursor), CursorOpLast)
 
   /** Move the cursor left in a JSON array the given number of times. A negative value will move the cursor right (alias for `leftN`). */
   def -<-:(n: Int): ACursor =
@@ -132,7 +132,7 @@ case class HCursor(cursor: Cursor, history: CursorHistory) {
 
   /** Find the first element at or to the right of focus in a JSON array where the given predicate matches the focus. */
   def find(p: Json => Boolean): ACursor =
-    history.acursorElement(Store(_.find(p), cursor), CursorOpRightAt(p))
+    history.acursorElement(Store(_.find(p), cursor), CursorOpFind(p))
 
   /** Move the cursor to the given sibling field in a JSON object (alias for `field`). */
   def --(q: JsonField): ACursor =
@@ -216,11 +216,11 @@ case class HCursor(cursor: Cursor, history: CursorHistory) {
 
   /** Set the values to the left of focus in a JSON array. */
   def setLefts(x: List[Json]): ACursor =
-    history.acursorElement(Store(_.setLefts(x), cursor), CursorOpDeleteRights)
+    history.acursorElement(Store(_.setLefts(x), cursor), CursorOpSetLefts(x))
 
   /** Set the values to the right of focus in a JSON array. */
   def setRights(x: List[Json]): ACursor =
-    history.acursorElement(Store(_.setRights(x), cursor), CursorOpDeleteRights)
+    history.acursorElement(Store(_.setRights(x), cursor), CursorOpSetRights(x))
 
   /** Move the cursor up one step to the parent context. */
   def up: ACursor =


### PR DESCRIPTION
The important part here is `first` and `last` in `HCursor`—the current implementations have copy-paste errors that mean that these operations are broken on both `HCursor` and `ACursor`.

I've also corrected a couple of similar cases of copy-paste errors in history tracking, and added two missing `CursorOpElement` types. I've made up what I think are reasonable string representations for these, but I'm happy to change them.

I haven't added any tests, since `HCursor` isn't currently tested directly. I'd be happy to add something for this in a separate PR.