### PR TITLE
The Big Hack Job

### DIFF
--- a/argonaut/src/main/scala/argonaut/ACursor.scala
+++ b/argonaut/src/main/scala/argonaut/ACursor.scala
@@ -13,7 +13,7 @@ case class ACursor(either: Either[HCursor, HCursor]) {
   def success: Option[HCursor] =
     hcursor
 
-  /** Get the failed hcursor if we are in an failed state. Alias for `hcursor`. */
+  /** Get the failed hcursor if we are in an failed state. */
   def failure: Option[HCursor] =
     either.left.toOption
 

--- a/project/ScalaSettings.scala
+++ b/project/ScalaSettings.scala
@@ -6,7 +6,7 @@ object ScalaSettings {
   type Sett = Def.Setting[_]
 
   lazy val all: Seq[Sett] = Seq(
-    scalaVersion := "2.11.6"
+    scalaVersion := "2.11.7"
   , crossScalaVersions := Seq("2.10.6", "2.11.7")
   , fork in test := true
   , scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:_", "-Xlint")

--- a/project/build.scala
+++ b/project/build.scala
@@ -14,7 +14,7 @@ object build extends Build {
   )
 
   val scalazVersion              = "7.1.4"
-  val paradiseVersion            = "2.0.1"
+  val paradiseVersion            = "2.1.0-M5"
   val monocleVersion             = "1.2.0-M1"
   val scalaz                     = "org.scalaz"                   %% "scalaz-core"               % scalazVersion
   val scalazScalaCheckBinding    = "org.scalaz"                   %% "scalaz-scalacheck-binding" % scalazVersion            % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
@@ -100,7 +100,7 @@ object build extends Build {
     )
   ).dependsOn(argonaut % "compile->compile;test->test", argonautScalaz % "compile->compile;test->test")
 
-  val benchmark = Project(
+  val argonautBenchmark = Project(
     id = "argonaut-benchmark"
   , base = file("argonaut-benchmark")
   , settings = base ++ Seq[Sett](
@@ -110,4 +110,14 @@ object build extends Build {
     , javaOptions in run <++= (fullClasspath in Runtime) map { cp => Seq("-cp", sbt.Attributed.data(cp).mkString(":")) }
     )
   ).dependsOn(argonaut)
+
+  val argonautParent = Project(
+    id = "argonaut-parent"
+  , base = file(".")
+  , settings = base ++ Seq[Sett](
+      name := "argonaut-parent"
+    , fork in run := true
+    , publishArtifact := false
+    )
+  ).aggregate(argonaut, argonautScalaz, argonautMonocle, argonautBenchmark)
 }


### PR DESCRIPTION
This creates 3 projects, argonaut, argonaut-scalaz and argonaut-monocle.

The core argonaut project has no dependencies on Scalaz or Monocle at all, for the moment the 3 projects will be in lock-step but I'm pondering a future where they don't need to be. The main change as a result of that is that there's a move back from \/ to Either.

There's a lot of empty traits/objects in there as a result of me moving things around, I'm tempted to think a few of them would likely end up with stuff in them

Paging @julien-truffaut for his input on the Monocle side of things.