### PR TITLE
Fix comment on ACursor#failure

### DIFF
--- a/src/main/scala/argonaut/ACursor.scala
+++ b/src/main/scala/argonaut/ACursor.scala
@@ -15,7 +15,7 @@ case class ACursor(either: HCursor \/ HCursor) {
   def success: Option[HCursor] =
     hcursor
 
-  /** Get the failed hcursor if we are in an failed state. Alias for `hcursor`. */
+  /** Get the failed hcursor if we are in an failed state. */
   def failure: Option[HCursor] =
     either.swap.toOption
 


### PR DESCRIPTION
Surely `.success` and `.failure` aren't aliases for the same thing :-)