### PR TITLE
upgrade monocle to 1.2.0-M1 and add various optics for argonaut data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: scala
 scala:
-   - 2.10.4
-   - 2.11.6
+   - 2.10.6
+   - 2.11.7
 jdk:
   - oraclejdk7
   - oraclejdk8

--- a/argonaut-monocle/src/main/scala/argonaut/ACursorMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/ACursorMonocle.scala
@@ -1,8 +1,14 @@
 package argonaut
 
-import scalaz._, syntax.applicative._
+import monocle.macros.GenIso
+import monocle.{Iso, Prism}
+import monocle.std.either
+
 
 object ACursorMonocle extends ACursorMonocles
 
 trait ACursorMonocles {
+  val aCursor: Iso[ACursor, Either[HCursor, HCursor]] = GenIso[ACursor, Either[HCursor, HCursor]]
+  val success: Prism[ACursor, HCursor] = aCursor composePrism either.stdRight
+  val fail: Prism[ACursor, HCursor]    = aCursor composePrism either.stdLeft
 }

--- a/argonaut-monocle/src/main/scala/argonaut/ArgonautMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/ArgonautMonocle.scala
@@ -1,21 +1,22 @@
 package argonaut
 
-object ArgonautMonocle extends ArgonautMonocles
+object ArgonautMonocle
+//  extends ArgonautMonocles
 
-trait ArgonautMonocles extends
-ACursorMonocles with
-CodecJsonMonocles with
-ContextMonocles with
-CursorMonocles with
-CursorHistoryMonocles with
-CursorOpMonocles with
-CursorOpElementMonocles with
-DecodeJsonMonocles with
-DecodeResultMonocles with
-EncodeJsonMonocles with
-HCursorMonocles with
-JsonMonocles with
-JsonIdentityMonocles with
-JsonObjectMonocles with
-PrettyParamsMonocles with
-StringWrapMonocles
+//trait ArgonautMonocles extends
+//ACursorMonocles with
+//CodecJsonMonocles with
+//ContextMonocles with
+//CursorMonocles with
+//CursorHistoryMonocles with
+//CursorOpMonocles with
+//CursorOpElementMonocles with
+//DecodeJsonMonocles with
+//DecodeResultMonocles with
+//EncodeJsonMonocles with
+//HCursorMonocles with
+//JsonMonocles with
+//JsonIdentityMonocles with
+//JsonObjectMonocles with
+//PrettyParamsMonocles with
+//StringWrapMonocles

--- a/argonaut-monocle/src/main/scala/argonaut/CodecJsonMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/CodecJsonMonocle.scala
@@ -1,7 +1,5 @@
 package argonaut
 
-import scalaz._, syntax.equal._
-
 object CodecJsonMonocle extends CodecJsonMonocles
 
 trait CodecJsonMonocles {

--- a/argonaut-monocle/src/main/scala/argonaut/CursorHistoryMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/CursorHistoryMonocle.scala
@@ -1,8 +1,10 @@
 package argonaut
 
-import scalaz._, syntax.show._, std.list._, syntax.equal._
+import monocle.Iso
+import monocle.macros.GenIso
 
 object CursorHistoryMonocle extends CursorHistoryMonocles
 
 trait CursorHistoryMonocles {
+  val cursorHistory: Iso[CursorHistory, List[CursorOp]] = GenIso[CursorHistory, List[CursorOp]]
 }

--- a/argonaut-monocle/src/main/scala/argonaut/CursorMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/CursorMonocle.scala
@@ -1,10 +1,5 @@
 package argonaut
 
-import scalaz._, syntax.show._, syntax.equal._
-import std.string._, std.list._
-import Json._
-import ContextElement._
-
 object CursorMonocle extends CursorMonocles
 
 trait CursorMonocles {

--- a/argonaut-monocle/src/main/scala/argonaut/CursorOpElementMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/CursorOpElementMonocle.scala
@@ -1,8 +1,5 @@
 package argonaut
 
-import Json._
-import scalaz._
-
 object CursorOpElementMonocle extends CursorOpElementMonocles
 
 trait CursorOpElementMonocles {

--- a/argonaut-monocle/src/main/scala/argonaut/CursorOpMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/CursorOpMonocle.scala
@@ -1,6 +1,14 @@
 package argonaut
 
-import scalaz._, syntax.show._
+import monocle.Prism
+import monocle.macros.{GenPrism, GenIso}
+
+object CursorOpMonocle extends CursorOpMonocles
 
 trait CursorOpMonocles {
+  val reattempt: Prism[CursorOp, Unit] = GenPrism[CursorOp, Reattempt.type] composeIso GenIso.unit[Reattempt.type]
+  val el: Prism[CursorOp, (CursorOpElement, Boolean)] = Prism[CursorOp, (CursorOpElement, Boolean)]{
+    case Reattempt       => None
+    case El(op, success) => Some((op, success))
+  }{case (op, success) => El(op, success)}
 }

--- a/argonaut-monocle/src/main/scala/argonaut/DecodeJsonMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/DecodeJsonMonocle.scala
@@ -1,12 +1,5 @@
 package argonaut
 
-import scala.math.{ Ordering => ScalaOrdering }
-import scala.collection.generic.CanBuildFrom
-import scala.collection.immutable.{ SortedSet, SortedMap, MapLike }
-import scala.util.control.Exception.catching
-import scalaz._, std.string._, syntax.either._, syntax.applicative._
-import Json._
-
 object DecodeJsonMonocle extends DecodeJsonMonocles
 
 trait DecodeJsonMonocles {

--- a/argonaut-monocle/src/main/scala/argonaut/DecodeResultMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/DecodeResultMonocle.scala
@@ -1,7 +1,17 @@
 package argonaut
 
-object DecodeResultMonocle extends DecodeResultMonocles {
-}
+import monocle.std.either
+import monocle.{Iso, Prism}
+
+object DecodeResultMonocle extends DecodeResultMonocles
 
 trait DecodeResultMonocles {
+  def cursorHistory[A]: Iso[DecodeResult[A], Either[(String, CursorHistory), A]] =
+    Iso[DecodeResult[A], Either[(String, CursorHistory), A]](_.toEither)(DecodeResult(_))
+
+  def success[A]: Prism[DecodeResult[A], A] =
+    cursorHistory composePrism either.stdRight
+
+  def fail[A]: Prism[DecodeResult[A], (String, CursorHistory)] =
+    cursorHistory composePrism either.stdLeft
 }

--- a/argonaut-monocle/src/main/scala/argonaut/EncodeJsonMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/EncodeJsonMonocle.scala
@@ -1,8 +1,5 @@
 package argonaut
 
-import scalaz._, syntax.either._
-import Json._
-
 object EncodeJsonMonocle extends EncodeJsonMonocles
 
 trait EncodeJsonMonocles {

--- a/argonaut-monocle/src/main/scala/argonaut/HCursorMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/HCursorMonocle.scala
@@ -1,10 +1,11 @@
 package argonaut
 
-import monocle.macros._
+import monocle.Lens
+import monocle.macros.GenLens
 
 object HCursorMonocle extends HCursorMonocles
 
 trait HCursorMonocles {
- val hCursorCursorL = GenLens[HCursor](_.cursor)
- val hCursorCursorHistoryL = GenLens[HCursor](_.history)
+ val cursor: Lens[HCursor, Cursor] = GenLens[HCursor](_.cursor)
+ val history: Lens[HCursor, CursorHistory] = GenLens[HCursor](_.history)
 }

--- a/argonaut-monocle/src/main/scala/argonaut/JsonObjectMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/JsonObjectMonocle.scala
@@ -1,10 +1,42 @@
 package argonaut
 
-import Json._
-import scalaz._, syntax.traverse._, syntax.show._
-import std.tuple._, std.string._
+import argonaut.Json._
+import monocle.function.{At, Each, FilterIndex, Index}
+import monocle.{Lens, Traversal}
+
+import scalaz.Applicative
+import scalaz.std.list._
+import scalaz.syntax.applicative._
 
 object JsonObjectMonocle extends JsonObjectMonocles
 
 trait JsonObjectMonocles {
+  implicit val jObjectEach = new Each[JsonObject, Json]{
+    def each = new Traversal[JsonObject, Json]{
+      def modifyF[F[_]: Applicative](f: Json => F[Json])(from: JsonObject): F[JsonObject] = {
+        JsonObjectScalaz.traverse(from, f)
+      }
+    }
+  }
+
+  implicit val jObjectAt = new At[JsonObject, JsonField, Json]{
+    def at(field: JsonField): Lens[JsonObject, Option[Json]] =
+      monocle.Lens[JsonObject, Option[Json]](_.apply(field))( optVal => jObj =>
+        optVal.fold(jObj - field)(value => jObj + (field, value))
+      )
+  }
+
+  implicit val jObjectFilterIndex = new FilterIndex[JsonObject, JsonField, Json]{
+    import scalaz.syntax.traverse._
+    def filterIndex(predicate: JsonField => Boolean) = new Traversal[JsonObject, Json]{
+      def modifyF[F[_]: Applicative](f: Json => F[Json])(from: JsonObject): F[JsonObject] =
+        Applicative[F].map(
+          from.toList.traverse[F, (JsonField, Json)]{ case (field, json) =>
+            Applicative[F].map(if(predicate(field)) f(json) else json.point[F])(field -> _)
+          }
+        )(JsonObject.fromTraversableOnce(_))
+    }
+  }
+
+  implicit val jObjectIndex: Index[JsonObject, JsonField, Json] = Index.atIndex
 }

--- a/argonaut-monocle/src/main/scala/argonaut/JsonParserMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/JsonParserMonocle.scala
@@ -1,10 +1,4 @@
 package argonaut
 
-import scala.annotation.tailrec
-import scalaz._, syntax.either._
-import Json._
-import java.lang.StringBuilder
-import scala.collection.mutable.Builder
-
 object JsonParserMonocle {
 }

--- a/argonaut-monocle/src/main/scala/argonaut/ParseMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/ParseMonocle.scala
@@ -1,7 +1,5 @@
 package argonaut
 
-import scalaz._, syntax.either._, syntax.show._
-
 object ParseMonocle extends ParseMonocles
 
 trait ParseMonocles {

--- a/argonaut-monocle/src/main/scala/argonaut/ParseWrapMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/ParseWrapMonocle.scala
@@ -1,3 +1,0 @@
-package argonaut
-
-import scalaz._

--- a/argonaut-monocle/src/main/scala/argonaut/PrettyParamsMonocle.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/PrettyParamsMonocle.scala
@@ -1,30 +1,28 @@
 package argonaut
 
+import monocle.Lens
 import monocle.macros.GenLens
-import scalaz._
-import scala.annotation._
 
 object PrettyParamsMonocle extends PrettyParamsMonocles
 
 trait PrettyParamsMonocles {
-  val lenser = GenLens[PrettyParams]
 
-  val indentL = lenser(_.indent)
-  val lbraceLeftL = lenser(_.lbraceLeft)
-  val lbraceRightL = lenser(_.lbraceRight)
-  val rbraceLeftL = lenser(_.rbraceLeft)
-  val rbraceRightL = lenser(_.rbraceRight)
-  val lbracketLeftL = lenser(_.lbracketLeft)
-  val lbracketRightL = lenser(_.lbracketRight)
-  val rbracketLeftL = lenser(_.rbracketLeft)
-  val rbracketRightL = lenser(_.rbracketRight)
-  val lrbracketsEmptyL = lenser(_.lrbracketsEmpty)
-  val arrayCommaLeftL = lenser(_.arrayCommaLeft)
-  val arrayCommaRightL = lenser(_.arrayCommaRight)
-  val objectCommaLeftL = lenser(_.objectCommaLeft)
-  val objectCommaRightL = lenser(_.objectCommaRight)
-  val colonLeftL = lenser(_.colonLeft)
-  val colonRightL = lenser(_.colonRight)
-  val preserveOrderL = lenser(_.preserveOrder)
-  val dropNullKeysL = lenser(_.dropNullKeys)
+  val indent: Lens[PrettyParams, String] = GenLens[PrettyParams](_.indent)
+  val lbraceLeft: Lens[PrettyParams, String] = GenLens[PrettyParams](_.lbraceLeft)
+  val lbraceRight: Lens[PrettyParams, String] = GenLens[PrettyParams](_.lbraceRight)
+  val rbraceLeft: Lens[PrettyParams, String] = GenLens[PrettyParams](_.rbraceLeft)
+  val rbraceRight: Lens[PrettyParams, String] = GenLens[PrettyParams](_.rbraceRight)
+  val lbracketLeft: Lens[PrettyParams, String] = GenLens[PrettyParams](_.lbracketLeft)
+  val lbracketRight: Lens[PrettyParams, String] = GenLens[PrettyParams](_.lbracketRight)
+  val rbracketLeft: Lens[PrettyParams, String] = GenLens[PrettyParams](_.rbracketLeft)
+  val rbracketRight: Lens[PrettyParams, String] = GenLens[PrettyParams](_.rbracketRight)
+  val lrbracketsEmpty: Lens[PrettyParams, String] = GenLens[PrettyParams](_.lrbracketsEmpty)
+  val arrayCommaLeft: Lens[PrettyParams, String] = GenLens[PrettyParams](_.arrayCommaLeft)
+  val arrayCommaRight: Lens[PrettyParams, String] = GenLens[PrettyParams](_.arrayCommaRight)
+  val objectCommaLeft: Lens[PrettyParams, String] = GenLens[PrettyParams](_.objectCommaLeft)
+  val objectCommaRight: Lens[PrettyParams, String] = GenLens[PrettyParams](_.objectCommaRight)
+  val colonLeft: Lens[PrettyParams, String] = GenLens[PrettyParams](_.colonLeft)
+  val colonRight: Lens[PrettyParams, String] = GenLens[PrettyParams](_.colonRight)
+  val preserveOrder: Lens[PrettyParams, Boolean] = GenLens[PrettyParams](_.preserveOrder)
+  val dropNullKeys: Lens[PrettyParams, Boolean] = GenLens[PrettyParams](_.dropNullKeys)
 }

--- a/argonaut-monocle/src/test/scala/argonaut/JsonMonocleSpecification.scala
+++ b/argonaut-monocle/src/test/scala/argonaut/JsonMonocleSpecification.scala
@@ -1,29 +1,31 @@
 package argonaut
 
 import argonaut.Data._
-import monocle.law.PrismLaws
+import argonaut.JsonNumberScalaz._
+import argonaut.JsonObjectScalaz._
+import argonaut.JsonScalaz._
+import monocle.law.discipline.PrismTests
 import org.specs2.{ScalaCheck, Specification}
 
 import scalaz.std.anyVal._
 import scalaz.std.list._
-import JsonScalaz._,JsonNumberScalaz._,JsonObjectScalaz._
 
 object JsonMonocleSpecification extends Specification with ScalaCheck {
 
   def is = s2"""
   Prism
-    JsonBoolean     ${PrismLaws(JsonMonocle.jBoolPrism)}
-    JsonNumber      ${PrismLaws(JsonMonocle.jNumberPrism)}
-    JsonArray       ${PrismLaws(JsonMonocle.jArrayPrism)}
-    JsonObject      ${PrismLaws(JsonMonocle.jObjectPrism)}
-    JsonBigDecimal  ${PrismLaws(JsonMonocle.jBigDecimalPrism)}
-    JsonDouble      ${PrismLaws(JsonMonocle.jDoublePrism)}
-    JsonFloat       ${PrismLaws(JsonMonocle.jDoublePrism)}
-    JsonBigInt      ${PrismLaws(JsonMonocle.jBigIntPrism)}
-    JsonLong        ${PrismLaws(JsonMonocle.jLongPrism)}
-    JsonInt         ${PrismLaws(JsonMonocle.jIntPrism)}
-    JsonShort       ${PrismLaws(JsonMonocle.jShortPrism)}
-    JsonByte        ${PrismLaws(JsonMonocle.jBytePrism)}
+    JsonBoolean     ${PrismTests(JsonMonocle.jBoolPrism).all}
+    JsonNumber      ${PrismTests(JsonMonocle.jNumberPrism).all}
+    JsonArray       ${PrismTests(JsonMonocle.jArrayPrism).all}
+    JsonObject      ${PrismTests(JsonMonocle.jObjectPrism).all}
+    JsonBigDecimal  ${PrismTests(JsonMonocle.jBigDecimalPrism).all}
+    JsonDouble      ${PrismTests(JsonMonocle.jDoublePrism).all}
+    JsonFloat       ${PrismTests(JsonMonocle.jDoublePrism).all}
+    JsonBigInt      ${PrismTests(JsonMonocle.jBigIntPrism).all}
+    JsonLong        ${PrismTests(JsonMonocle.jLongPrism).all}
+    JsonInt         ${PrismTests(JsonMonocle.jIntPrism).all}
+    JsonShort       ${PrismTests(JsonMonocle.jShortPrism).all}
+    JsonByte        ${PrismTests(JsonMonocle.jBytePrism).all}
   """
   
 }

--- a/argonaut-monocle/src/test/scala/argonaut/PrettyParamsMonocleSpecification.scala
+++ b/argonaut-monocle/src/test/scala/argonaut/PrettyParamsMonocleSpecification.scala
@@ -1,20 +1,13 @@
 package argonaut
 
-import org.scalacheck.Arbitrary
+import argonaut.Data._
+import argonaut.PrettyParamsScalaz._
+import monocle.law.discipline.LensTests
 import org.scalacheck.Arbitrary._
-import org.scalacheck.Prop
-import org.scalacheck.Prop._
-import org.scalacheck.Properties
-import org.scalacheck.Gen
-import Data._
-import Argonaut._
 import org.specs2._
-import scalaz._
-import scalaz.std.string._
+
 import scalaz.std.anyVal._
-import scalaz.scalacheck.ScalazArbitrary._
-import monocle.law.LensLaws
-import PrettyParamsScalaz._
+import scalaz.std.string._
 
 object PrettyParamsMonocleSpecification extends Specification with ScalaCheck {
   def is = s2"""
@@ -38,21 +31,21 @@ object PrettyParamsMonocleSpecification extends Specification with ScalaCheck {
     dropNullKeys      $dropNullKeysLens
   """
 
-  def lbraceLeftLens = LensLaws(PrettyParamsMonocle.lbraceLeftL)
-  def lbraceRightLens = LensLaws(PrettyParamsMonocle.lbraceRightL)
-  def rbraceLeftLens = LensLaws(PrettyParamsMonocle.rbraceLeftL)
-  def rbraceRightLens = LensLaws(PrettyParamsMonocle.rbraceRightL)
-  def lbracketLeftLens = LensLaws(PrettyParamsMonocle.lbracketLeftL)
-  def lbracketRightLens = LensLaws(PrettyParamsMonocle.lbracketRightL)
-  def rbracketLeftLens = LensLaws(PrettyParamsMonocle.rbracketLeftL)
-  def rbracketRightLens = LensLaws(PrettyParamsMonocle.rbracketRightL)
-  def lrbracketsEmptyLens = LensLaws(PrettyParamsMonocle.lrbracketsEmptyL)
-  def arrayCommaLeftLens = LensLaws(PrettyParamsMonocle.arrayCommaLeftL)
-  def arrayCommaRightLens = LensLaws(PrettyParamsMonocle.arrayCommaRightL)
-  def objectCommaLeftLens = LensLaws(PrettyParamsMonocle.objectCommaLeftL)
-  def objectCommaRightLens = LensLaws(PrettyParamsMonocle.objectCommaRightL)
-  def colonLeftLens = LensLaws(PrettyParamsMonocle.colonLeftL)
-  def colonRightLens = LensLaws(PrettyParamsMonocle.colonRightL)
-  def preserveOrderLens = LensLaws(PrettyParamsMonocle.preserveOrderL)
-  def dropNullKeysLens = LensLaws(PrettyParamsMonocle.dropNullKeysL)
+  def lbraceLeftLens = LensTests(PrettyParamsMonocle.lbraceLeft).all
+  def lbraceRightLens = LensTests(PrettyParamsMonocle.lbraceRight).all
+  def rbraceLeftLens = LensTests(PrettyParamsMonocle.rbraceLeft).all
+  def rbraceRightLens = LensTests(PrettyParamsMonocle.rbraceRight).all
+  def lbracketLeftLens = LensTests(PrettyParamsMonocle.lbracketLeft).all
+  def lbracketRightLens = LensTests(PrettyParamsMonocle.lbracketRight).all
+  def rbracketLeftLens = LensTests(PrettyParamsMonocle.rbracketLeft).all
+  def rbracketRightLens = LensTests(PrettyParamsMonocle.rbracketRight).all
+  def lrbracketsEmptyLens = LensTests(PrettyParamsMonocle.lrbracketsEmpty).all
+  def arrayCommaLeftLens = LensTests(PrettyParamsMonocle.arrayCommaLeft).all
+  def arrayCommaRightLens = LensTests(PrettyParamsMonocle.arrayCommaRight).all
+  def objectCommaLeftLens = LensTests(PrettyParamsMonocle.objectCommaLeft).all
+  def objectCommaRightLens = LensTests(PrettyParamsMonocle.objectCommaRight).all
+  def colonLeftLens = LensTests(PrettyParamsMonocle.colonLeft).all
+  def colonRightLens = LensTests(PrettyParamsMonocle.colonRight).all
+  def preserveOrderLens = LensTests(PrettyParamsMonocle.preserveOrder).all
+  def dropNullKeysLens = LensTests(PrettyParamsMonocle.dropNullKeys).all
 }

--- a/project/ScalaSettings.scala
+++ b/project/ScalaSettings.scala
@@ -7,7 +7,7 @@ object ScalaSettings {
 
   lazy val all: Seq[Sett] = Seq(
     scalaVersion := "2.11.6"
-  , crossScalaVersions := Seq("2.10.4", "2.11.6")
+  , crossScalaVersions := Seq("2.10.6", "2.11.7")
   , fork in test := true
   , scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:_", "-Xlint")
   // https://gist.github.com/djspiewak/976cd8ac65e20e136f05

--- a/project/build.scala
+++ b/project/build.scala
@@ -15,7 +15,7 @@ object build extends Build {
 
   val scalazVersion              = "7.1.4"
   val paradiseVersion            = "2.0.1"
-  val monocleVersion             = "1.1.0"
+  val monocleVersion             = "1.2.0-M1"
   val scalaz                     = "org.scalaz"                   %% "scalaz-core"               % scalazVersion
   val scalazScalaCheckBinding    = "org.scalaz"                   %% "scalaz-scalacheck-binding" % scalazVersion            % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
   val scalacheck                 = "org.scalacheck"               %% "scalacheck"                % "1.11.4"                 % "test"


### PR DESCRIPTION
We need to agree on naming convention and scope. At the moment, some optics have the same name e.g. `success` for `ACursor` and `DecodeResult`.