### PR TITLE
specify _root_.argonaut.EncodeJson in macro expansions

### DIFF
--- a/src/main/scala/argonaut/internal/Macros.scala
+++ b/src/main/scala/argonaut/internal/Macros.scala
@@ -11,7 +11,7 @@ object Macros extends MacrosCompat {
     val encode = materializeEncodeImpl[T](c)
     val decode = materializeDecodeImpl[T](c)
     c.Expr[CodecJson[T]](q"""
-    CodecJson.derived[$tpe]($encode, $decode)
+    _root_.argonaut.CodecJson.derived[$tpe]($encode, $decode)
     """)
   }
 
@@ -38,7 +38,7 @@ object Macros extends MacrosCompat {
         }
         val methodName = createTermName(c)("jencode" + (fieldCount.toString) + "L")
         c.Expr[EncodeJson[T]]{q"""
-          EncodeJson.$methodName[$tpe, ..$fieldTypes](toEncode => (..$invocations))(..$decodedNames)
+          _root_.argonaut.EncodeJson.$methodName[$tpe, ..$fieldTypes](toEncode => (..$invocations))(..$decodedNames)
         """}
       }
       case None => c.abort(c.enclosingPosition, "Could not identify primary constructor for " + tpe)
@@ -72,7 +72,7 @@ object Macros extends MacrosCompat {
         }
         val methodName = createTermName(c)("jdecode" + (fieldCount.toString) + "L")
         c.Expr[DecodeJson[T]]{q"""
-          DecodeJson.$methodName[..$fieldTypes, $tpe]((..$functionParameters) => new $tpe(..$parameters))(..$decodedNames)
+          _root_.argonaut.DecodeJson.$methodName[..$fieldTypes, $tpe]((..$functionParameters) => new $tpe(..$parameters))(..$decodedNames)
         """}
       }
       case None => c.abort(c.enclosingPosition, "Could not identify primary constructor for " + tpe)


### PR DESCRIPTION
This change allows you to call `argonaut.EncodeJson.derive` without `import argonaut.EncodeJson`, etc.  (The macro expansion relies on the imports at the expansion site, not the declaration file.)