### PR TITLE
Fix bug in leftAt matching case

### DIFF
--- a/argonaut/src/main/scala/argonaut/Cursor.scala
+++ b/argonaut/src/main/scala/argonaut/Cursor.scala
@@ -176,7 +176,7 @@ sealed abstract class Cursor extends Product with Serializable {
     def r(c: Option[Cursor]): Option[Cursor] =
       c match {
         case None => None
-        case Some(w) => r(if(p(w.focus)) Some(w) else w.left)
+        case Some(w) => if (p(w.focus)) Some(w) else r(w.left)
       }
 
     r(left)

--- a/argonaut/src/test/scala/argonaut/CursorSpecification.scala
+++ b/argonaut/src/test/scala/argonaut/CursorSpecification.scala
@@ -31,6 +31,8 @@ object CursorSpecification extends Specification with ScalaCheck {
     downAt                                     $downAt
     first                                      $first
     last                                       $last
+    leftAt                                     $leftAt
+    left                                       $left
     rightAt                                    $rightAt
     right                                      $right
     right is same as rightN(1)                 $rightOne
@@ -58,6 +60,12 @@ object CursorSpecification extends Specification with ScalaCheck {
 
   def last = prop((ys: List[Json], x: Json, xs: List[Json], z: Json) =>
     jArray(ys ::: (x :: xs) ::: List(z)).cursor.downAt(_ == x).flatMap(_.last).map(_.focus) must_== Some(z))
+
+  def leftAt = prop((xx: Json, x: Json, xs: List[Json]) =>
+    jArray(xx :: x :: xs).cursor.downN(1).flatMap(_.leftAt(_ => true)).map(_.focus) must_== Some(xx))
+
+  def left = prop((xx: Json, x: Json, xs: List[Json]) =>
+    jArray(xx :: x :: xs).cursor.downN(1).flatMap(_.left).map(_.focus) must_== Some(xx))
 
   def rightAt = prop((xx: Json, x: Json, xs: List[Json]) =>
     jArray(xx :: x :: xs).cursor.downArray.flatMap(_.rightAt(_ => true)).map(_.focus) must_== Some(x))


### PR DESCRIPTION
Just noticed while [writing tests for circe](https://github.com/travisbrown/circe/pull/114) that the recursion is in the wrong place here, and results in `leftAt` never returning when the predicate matches. I've added tests for both `left` and `leftAt`.