### PR TITLE
Support backtick identifier names in derived codecs

### DIFF
--- a/src/main/scala/argonaut/internal/Macros.scala
+++ b/src/main/scala/argonaut/internal/Macros.scala
@@ -32,8 +32,8 @@ object Macros extends MacrosCompat {
           getDeclaration(c)(tpe, field.name).typeSignature
         }
         val fieldCount = fieldNames.size
-        val invocations = decodedNames.map{fieldName => 
-          val termName = createTermName(c)(fieldName)
+        val invocations = fieldNames.map{fieldName =>
+          val termName = createTermName(c)(fieldName.toString)
           q"toEncode.$termName"
         }
         val methodName = createTermName(c)("jencode" + (fieldCount.toString) + "L")
@@ -62,12 +62,12 @@ object Macros extends MacrosCompat {
           getDeclaration(c)(tpe, field.name).typeSignature
         }
         val fieldCount = fieldNames.size
-        val functionParameters = decodedNames.zip(fieldTypes).map{case (fieldName, fieldType) =>
-          val termName = createTermName(c)(fieldName)
+        val functionParameters = fieldNames.zip(fieldTypes).map{case (fieldName, fieldType) =>
+          val termName = createTermName(c)(fieldName.toString)
           q"$termName: $fieldType"
         }
-        val parameters = decodedNames.map{fieldName =>
-          val termName = createTermName(c)(fieldName)
+        val parameters = fieldNames.map{fieldName =>
+          val termName = createTermName(c)(fieldName.toString)
           q"$termName"
         }
         val methodName = createTermName(c)("jdecode" + (fieldCount.toString) + "L")

--- a/src/test/scala/argonaut/TestTypes.scala
+++ b/src/test/scala/argonaut/TestTypes.scala
@@ -7,7 +7,7 @@ import org.specs2._, org.specs2.specification._
 case class Product(name: String, price: Double)
 case class OrderLine(product: Product, quantity: Int)
 case class Order(orderLines: Vector[OrderLine])
-case class Person(name: String, age: Int, orders: Vector[Order], addressFields: Map[String, String])
+case class Person(`full.name`: String, age: Int, orders: Vector[Order], addressFields: Map[String, String])
 
 sealed trait Shape
 case class Circle(radius: Int) extends Shape


### PR DESCRIPTION
Make derived codecs work with case classes that use backtick encoded field names. For example

```scala
case class Example(`message.type`: String, `message.id`: Int)
implicit def ExampleCodec = CodecJson.derive[Example]
```

Currently this would result in an error like: `value message.type is not a member of Example`. Note that this already works correctly for manually generated codes using `casecodec2`.

The solution is to change the macros to use the decoded field names for the text strings that name the fields but to use the encoded field names when referring to the fields themselves. Here is an sbt console session showing this in action.

```
scala> case class Example(`message.type`: String, `message.id`: Int)
defined class Example

scala> implicit def ExampleCodec = CodecJson.derive[Example]
ExampleCodec: argonaut.CodecJson[Example]

scala> Example("type", 1).asJson.spaces2
res0: String =
{
  "message.type" : "type",
  "message.id" : 1
}

scala> res0.decodeOption[Example]
res1: Option[Example] = Some(Example(type,1))
```

For unit tests I changed the `Person` case class in TestTypes.scala so that the `name` field is now `full.name`.