### PR TITLE
Add cats module

### DIFF
--- a/argonaut-cats/src/main/scala/argonaut/ACursorCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/ACursorCats.scala
@@ -1,0 +1,7 @@
+package argonaut
+
+object ACursorCats extends ACursorCatss {
+}
+
+trait ACursorCatss {
+}

--- a/argonaut-cats/src/main/scala/argonaut/ArgonautCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/ArgonautCats.scala
@@ -1,0 +1,22 @@
+package argonaut
+
+object ArgonautCats extends ArgonautCatss
+
+trait ArgonautCatss
+extends ACursorCatss
+with CodecJsonCatss
+with ContextCatss
+with ContextElementCatss
+with CursorCatss
+with CursorHistoryCatss
+with CursorOpCatss
+with CursorOpElementCatss
+with DecodeJsonCatss
+with DecodeResultCatss
+with EncodeJsonCatss
+with HCursorCatss
+with JsonCatss
+with JsonIdentityCatss
+with JsonObjectCatss
+with PrettyParamsCatss
+with StringWrapCatss

--- a/argonaut-cats/src/main/scala/argonaut/CodecJsonCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/CodecJsonCats.scala
@@ -1,0 +1,7 @@
+package argonaut
+
+object CodecJsonCats extends CodecJsonCatss {
+}
+
+trait CodecJsonCatss {
+}

--- a/argonaut-cats/src/main/scala/argonaut/ContextCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/ContextCats.scala
@@ -1,11 +1,8 @@
 package argonaut
 
-import argonaut.ContextElementCats._
-import argonaut.JsonCats._
-import cats._
-import cats.std.all._
-import cats.syntax.eq._
-import cats.syntax.show._
+import ContextElementCats._
+import JsonCats._
+import cats._, std.all._, syntax.eq._, syntax.show._
 
 object ContextCats extends ContextCatss
 

--- a/argonaut-cats/src/main/scala/argonaut/ContextCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/ContextCats.scala
@@ -1,0 +1,51 @@
+package argonaut
+
+import argonaut.ContextElementCats._
+import argonaut.JsonCats._
+import cats._
+import cats.std.all._
+import cats.syntax.eq._
+import cats.syntax.show._
+
+object ContextCats extends ContextCatss
+
+trait ContextCatss {
+  implicit val ContextInstances: Eq[Context] with Show[Context] = {
+    new Eq[Context] with Show[Context] {
+      def eqv(c1: Context, c2: Context) = {
+        Eq.by((_: Context).toList).eqv(c1, c2)
+      }
+      override def show(c: Context) = {
+        c.toList.map(_.show).mkString(".")
+      }
+    }
+  }
+}
+
+object ContextElementCats extends ContextElementCatss
+
+trait ContextElementCatss {
+  implicit val ContextElementInstances: Eq[ContextElement] with Show[ContextElement] = {
+    new Eq[ContextElement] with Show[ContextElement] {
+      override def eqv(c1: ContextElement, c2: ContextElement) = {
+        c1 match {
+          case ArrayContext(n1, j1) => c2 match {
+            case ArrayContext(n2, j2) => n1 === n2 && j1 === j2
+            case ObjectContext(_, _) => false
+          }
+          case ObjectContext(f1, j1) => c2 match {
+            case ObjectContext(f2, j2) => f1 === f2 && j1 === j2
+            case ArrayContext(_, _) => false
+          }
+        }
+      }
+
+      override def show(c: ContextElement) = {
+        c match {
+          case ArrayContext(n, j) => "[" + n + "]"
+          case ObjectContext(f, j) => "{" + f + "}"
+        }
+      }
+    }
+  }
+}

--- a/argonaut-cats/src/main/scala/argonaut/ContextCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/ContextCats.scala
@@ -2,7 +2,8 @@ package argonaut
 
 import ContextElementCats._
 import JsonCats._
-import cats._, std.all._, syntax.eq._, syntax.show._
+import cats._, std.all._
+import syntax.eq._, syntax.show._
 
 object ContextCats extends ContextCatss
 

--- a/argonaut-cats/src/main/scala/argonaut/CursorCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/CursorCats.scala
@@ -3,7 +3,9 @@ package argonaut
 import ContextCats._
 import JsonCats._
 import JsonObjectCats._
-import cats._, std.list._, syntax.eq._, syntax.show._
+import cats._
+import std.list._, std.string._
+import syntax.eq._, syntax.show._
 
 object CursorCats extends CursorCatss {
 }

--- a/argonaut-cats/src/main/scala/argonaut/CursorCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/CursorCats.scala
@@ -1,0 +1,41 @@
+package argonaut
+
+import argonaut.ContextCats._
+import argonaut.JsonCats._
+import argonaut.JsonObjectCats._
+import cats._
+import cats.std.list._
+import cats.std.string._
+import cats.syntax.eq._
+import cats.syntax.show._
+
+object CursorCats extends CursorCatss {
+}
+
+trait CursorCatss {
+  implicit val CursorInstances: Eq[Cursor] with Show[Cursor] = new Eq[Cursor] with Show[Cursor] {
+    def eqv(c1: Cursor, c2: Cursor) = {
+      c1 match {
+        case CJson(j1) =>
+          c2 match {
+            case CJson(j2) => j1 === j2
+            case _ => false
+          }
+        case CArray(p1, _, l1, j1, r1) =>
+          c2 match {
+            case CArray(p2, _, l2, j2, r2) => p1 === p2 && l1 === l2 && j1 === j2 && r1 === r2
+            case _ => false
+          }
+        case CObject(p1, _, x1, (f1, j1)) =>
+          c2 match {
+            case CObject(p2, _, x2, (f2, j2)) => p1 === p2 && x1 === x2 && f1 === f2 && j1 === j2
+            case _ => false
+          }
+      }
+    }
+
+    override def show(c: Cursor) = {
+      c.context.show + " ==> " + c.focus.show
+    }
+  }
+}

--- a/argonaut-cats/src/main/scala/argonaut/CursorCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/CursorCats.scala
@@ -1,13 +1,9 @@
 package argonaut
 
-import argonaut.ContextCats._
-import argonaut.JsonCats._
-import argonaut.JsonObjectCats._
-import cats._
-import cats.std.list._
-import cats.std.string._
-import cats.syntax.eq._
-import cats.syntax.show._
+import ContextCats._
+import JsonCats._
+import JsonObjectCats._
+import cats._, std.list._, syntax.eq._, syntax.show._
 
 object CursorCats extends CursorCatss {
 }

--- a/argonaut-cats/src/main/scala/argonaut/CursorHistoryCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/CursorHistoryCats.scala
@@ -1,0 +1,23 @@
+package argonaut
+
+import argonaut.CursorOpCats._
+import cats._
+import cats.std.list._
+import cats.syntax.eq._
+
+object CursorHistoryCats extends CursorHistoryCatss
+
+trait CursorHistoryCatss {
+  implicit val CursorHistoryInstances: Show[CursorHistory] with Eq[CursorHistory] with Monoid[CursorHistory] = {
+    new Show[CursorHistory] with Eq[CursorHistory] with Monoid[CursorHistory] {
+      override def show(h: CursorHistory) = Show[List[CursorOp]].show(h.toList)
+      def eqv(h1: CursorHistory, h2: CursorHistory) = {
+        h1.toList === h2.toList
+      }
+      def empty = CursorHistory(List())
+      def combine(h1: CursorHistory, h2: CursorHistory) = {
+        CursorHistory(h1.toList ::: h2.toList)
+      }
+    }
+  }
+}

--- a/argonaut-cats/src/main/scala/argonaut/CursorHistoryCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/CursorHistoryCats.scala
@@ -1,9 +1,7 @@
 package argonaut
 
-import argonaut.CursorOpCats._
-import cats._
-import cats.std.list._
-import cats.syntax.eq._
+import CursorOpCats._
+import cats._, std.list._, syntax.eq._
 
 object CursorHistoryCats extends CursorHistoryCatss
 

--- a/argonaut-cats/src/main/scala/argonaut/CursorHistoryCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/CursorHistoryCats.scala
@@ -1,7 +1,9 @@
 package argonaut
 
 import CursorOpCats._
-import cats._, std.list._, syntax.eq._
+import cats._
+import std.list._
+import syntax.eq._
 
 object CursorHistoryCats extends CursorHistoryCatss
 

--- a/argonaut-cats/src/main/scala/argonaut/CursorOpCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/CursorOpCats.scala
@@ -1,7 +1,8 @@
 package argonaut
 
 import CursorOpElementCats._
-import cats._, syntax.show._
+import cats._
+import syntax.show._
 
 object CursorOpCats extends CursorOpCatss {
 }

--- a/argonaut-cats/src/main/scala/argonaut/CursorOpCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/CursorOpCats.scala
@@ -1,0 +1,22 @@
+package argonaut
+
+import argonaut.CursorOpElementCats._
+import cats._
+import cats.syntax.show._
+
+object CursorOpCats extends CursorOpCatss {
+}
+
+trait CursorOpCatss {
+  implicit val CursorOpInstances: Show[CursorOp] with Eq[CursorOp] = {
+    new Show[CursorOp] with Eq[CursorOp] {
+      override def show(x: CursorOp) = x match {
+        case Reattempt => ".?."
+        case El(o, s) => if (s) o.show else '*' +: '.' +: o.show
+      }
+      def eqv(a1: CursorOp, a2: CursorOp) = {
+        a1 == a2
+      }
+    }
+  }
+}

--- a/argonaut-cats/src/main/scala/argonaut/CursorOpCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/CursorOpCats.scala
@@ -1,8 +1,7 @@
 package argonaut
 
-import argonaut.CursorOpElementCats._
-import cats._
-import cats.syntax.show._
+import CursorOpElementCats._
+import cats._, syntax.show._
 
 object CursorOpCats extends CursorOpCatss {
 }

--- a/argonaut-cats/src/main/scala/argonaut/CursorOpElementCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/CursorOpElementCats.scala
@@ -1,0 +1,45 @@
+package argonaut
+
+import cats._
+
+object CursorOpElementCats extends CursorOpElementCatss
+
+trait CursorOpElementCatss {
+  implicit val CursorOpElementInstances: Show[CursorOpElement] with Eq[CursorOpElement] = {
+    new Show[CursorOpElement] with Eq[CursorOpElement] {
+      override def show(e: CursorOpElement) = {
+        e match {
+          case CursorOpLeft => "<-"
+          case CursorOpRight => "->"
+          case CursorOpFirst => "|<-"
+          case CursorOpLast => "->|"
+          case CursorOpUp => "_/"
+          case CursorOpLeftN(n) => "-<-:(" + n + ")"
+          case CursorOpRightN(n) => ":->-(" + n + ")"
+          case CursorOpLeftAt(_) => "?<-:"
+          case CursorOpRightAt(_) => ":->?"
+          case CursorOpFind(_) => "find"
+          case CursorOpField(f) => "--(" + f + ")"
+          case CursorOpDownField(f) => "--\\(" + f + ")"
+          case CursorOpDownArray => "\\\\"
+          case CursorOpDownAt(_) => "-\\"
+          case CursorOpDownN(n) => "=\\(" + n + ")"
+          case CursorOpDeleteGoParent => "!_/"
+          case CursorOpDeleteGoLeft => "<-!"
+          case CursorOpDeleteGoRight => "!->"
+          case CursorOpDeleteGoFirst => "|<-!"
+          case CursorOpDeleteGoLast => "!->|"
+          case CursorOpDeleteGoField(f) => "!--(" + f + ")"
+          case CursorOpDeleteLefts => "!<"
+          case CursorOpDeleteRights => ">!"
+          case CursorOpSetLefts(_) => "!...<"
+          case CursorOpSetRights(_) => ">...!"
+        }
+      }
+
+      def eqv(e1: CursorOpElement, e2: CursorOpElement) = {
+        e1 == e2
+      }
+    }
+  }
+}

--- a/argonaut-cats/src/main/scala/argonaut/DecodeJsonCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/DecodeJsonCats.scala
@@ -1,0 +1,32 @@
+package argonaut
+
+import cats.data._
+
+object DecodeJsonCats extends DecodeJsonCatss {
+}
+
+trait DecodeJsonCatss {
+  implicit def XorDecodeJson[A: DecodeJson, B: DecodeJson](implicit DE: DecodeJson[Either[A, B]]): DecodeJson[Xor[A, B]] = {
+    DE.map(Xor.fromEither(_))
+  }
+
+  implicit def ValidationDecodeJson[A, B](implicit DA: DecodeJson[A], DB: DecodeJson[B]): DecodeJson[Validated[A, B]] = {
+    DecodeJson(a => {
+      val l = (a --\ "Invalid").success
+      val r = (a --\ "Valid").success
+      (l, r) match {
+        case (Some(c), None) => DA(c).map(Validated.Invalid(_))
+        case (None, Some(c)) => DB(c).map(Validated.Valid(_))
+        case _ => DecodeResult.fail("[A, B]Validated[A, B]", a.history)
+      }
+    })
+  }
+
+  implicit def NonEmptyListDecodeJson[A: DecodeJson](implicit DL: DecodeJson[List[A]]): DecodeJson[NonEmptyList[A]] = {
+    DL.flatMap(l =>
+      DecodeJson[NonEmptyList[A]](c => NonEmptyList.fromList(l) match {
+        case None => DecodeResult.fail("[A]NonEmptyList[A]", c.history)
+        case Some(n) => DecodeResult.ok(n)
+      })) setName "[A]NonEmptyList[A]"
+  }
+}

--- a/argonaut-cats/src/main/scala/argonaut/DecodeResultCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/DecodeResultCats.scala
@@ -5,7 +5,9 @@ import cats._, data._, syntax.contravariant._, syntax.eq._, syntax.show._
 object DecodeResultCats extends DecodeResultCatss {
 }
 
-trait DecodeResultCatss extends TupleInstances0 {
+trait DecodeResultCatss {
+  import TupleInstances._
+  
   @annotation.tailrec
   final def loop[A, X](d: DecodeResult[A], e: (String, CursorHistory) => X, f: A => Xor[X, DecodeResult[A]]): X = {
     if (d.isError) {
@@ -33,7 +35,9 @@ trait DecodeResultCatss extends TupleInstances0 {
     SE.contramap(_.toEither)
 }
 
-trait TupleInstances0 {
+private object TupleInstances extends TupleInstances0
+
+private trait TupleInstances0 {
 
   implicit def Tuple2Eq[A, B](implicit EA: Eq[A], EB: Eq[B]): Eq[(A, B)] = new Eq[(A, B)] {
     override def eqv(x: (A, B), y: (A, B)): Boolean = x._1 === y._1 && x._2 === y._2

--- a/argonaut-cats/src/main/scala/argonaut/DecodeResultCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/DecodeResultCats.scala
@@ -1,6 +1,9 @@
 package argonaut
 
-import cats._, data._, syntax.contravariant._, syntax.eq._, syntax.show._
+import CursorHistoryCats._
+import cats._, data._
+import std.either._, std.string._
+import syntax.contravariant._, syntax.eq._, syntax.show._
 
 object DecodeResultCats extends DecodeResultCatss {
 }
@@ -22,8 +25,8 @@ trait DecodeResultCatss {
 
   type DecodeEither[A] = Either[(String, CursorHistory), A]
 
-  implicit def DecodeResultEq[A](implicit EE: Eq[DecodeEither[A]]): Eq[DecodeResult[A]] =
-    EE.on(_.toEither)
+  implicit def DecodeResultEq[A](implicit EA: Eq[A]): Eq[DecodeResult[A]] =
+    eitherEq[(String, CursorHistory), A].on(_.toEither)
 
   implicit def DecodeResultMonad: Monad[DecodeResult] = new Monad[DecodeResult] {
     def pure[A](a: A) = DecodeResult.ok(a)

--- a/argonaut-cats/src/main/scala/argonaut/DecodeResultCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/DecodeResultCats.scala
@@ -1,0 +1,49 @@
+package argonaut
+
+import cats._
+import cats.data._
+import cats.syntax.contravariant._
+import cats.syntax.eq._
+import cats.syntax.show._
+
+object DecodeResultCats extends DecodeResultCatss {
+}
+
+trait DecodeResultCatss extends TupleInstances0 {
+  @annotation.tailrec
+  final def loop[A, X](d: DecodeResult[A], e: (String, CursorHistory) => X, f: A => Xor[X, DecodeResult[A]]): X = {
+    if (d.isError) {
+      e(d.message.get, d.history.get)
+    } else {
+      f(d.value.get) match {
+        case Xor.Left(x) => x
+        case Xor.Right(a) => loop(a, e, f)
+      }
+    }
+  }
+
+  implicit def DecodeResultMonad: Monad[DecodeResult] = new Monad[DecodeResult] {
+    def pure[A](a: A) = DecodeResult.ok(a)
+    def flatMap[A, B](a: DecodeResult[A])(f: A => DecodeResult[B]) = a flatMap f
+    override def map[A, B](a: DecodeResult[A])(f: A => B) = a map f
+  }
+
+  type DecodeEither[A] = Either[(String, CursorHistory), A]
+
+  implicit def DecodeResultEq[A](implicit EE: Eq[DecodeEither[A]]): Eq[DecodeResult[A]] =
+    EE.on(_.toEither)
+
+  implicit def DecodeResultShow[A](implicit SE: Show[DecodeEither[A]]): Show[DecodeResult[A]] =
+    SE.contramap(_.toEither)
+}
+
+trait TupleInstances0 {
+
+  implicit def tuple2Eq[A, B](implicit EA: Eq[A], EB: Eq[B]): Eq[(A, B)] = new Eq[(A, B)] {
+    override def eqv(x: (A, B), y: (A, B)): Boolean = x._1 === y._1 && x._2 === y._2
+  }
+
+  implicit def tuple2Show[A, B](implicit SA: Show[A], SB: Show[B]): Show[(A, B)] = new Show[(A, B)] {
+    override def show(f: (A, B)): String = s"(${f._1.show}, ${f._2.show}}"
+  }
+}

--- a/argonaut-cats/src/main/scala/argonaut/DecodeResultCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/DecodeResultCats.scala
@@ -1,10 +1,6 @@
 package argonaut
 
-import cats._
-import cats.data._
-import cats.syntax.contravariant._
-import cats.syntax.eq._
-import cats.syntax.show._
+import cats._, data._, syntax.contravariant._, syntax.eq._, syntax.show._
 
 object DecodeResultCats extends DecodeResultCatss {
 }
@@ -22,16 +18,16 @@ trait DecodeResultCatss extends TupleInstances0 {
     }
   }
 
+  type DecodeEither[A] = Either[(String, CursorHistory), A]
+
+  implicit def DecodeResultEq[A](implicit EE: Eq[DecodeEither[A]]): Eq[DecodeResult[A]] =
+    EE.on(_.toEither)
+
   implicit def DecodeResultMonad: Monad[DecodeResult] = new Monad[DecodeResult] {
     def pure[A](a: A) = DecodeResult.ok(a)
     def flatMap[A, B](a: DecodeResult[A])(f: A => DecodeResult[B]) = a flatMap f
     override def map[A, B](a: DecodeResult[A])(f: A => B) = a map f
   }
-
-  type DecodeEither[A] = Either[(String, CursorHistory), A]
-
-  implicit def DecodeResultEq[A](implicit EE: Eq[DecodeEither[A]]): Eq[DecodeResult[A]] =
-    EE.on(_.toEither)
 
   implicit def DecodeResultShow[A](implicit SE: Show[DecodeEither[A]]): Show[DecodeResult[A]] =
     SE.contramap(_.toEither)
@@ -39,11 +35,11 @@ trait DecodeResultCatss extends TupleInstances0 {
 
 trait TupleInstances0 {
 
-  implicit def tuple2Eq[A, B](implicit EA: Eq[A], EB: Eq[B]): Eq[(A, B)] = new Eq[(A, B)] {
+  implicit def Tuple2Eq[A, B](implicit EA: Eq[A], EB: Eq[B]): Eq[(A, B)] = new Eq[(A, B)] {
     override def eqv(x: (A, B), y: (A, B)): Boolean = x._1 === y._1 && x._2 === y._2
   }
 
-  implicit def tuple2Show[A, B](implicit SA: Show[A], SB: Show[B]): Show[(A, B)] = new Show[(A, B)] {
-    override def show(f: (A, B)): String = s"(${f._1.show}, ${f._2.show}}"
+  implicit def Tuple2Show[A, B](implicit SA: Show[A], SB: Show[B]): Show[(A, B)] = new Show[(A, B)] {
+    override def show(f: (A, B)): String = "(" + f._1.show + ", " + f._2.show + "}"
   }
 }

--- a/argonaut-cats/src/main/scala/argonaut/EncodeJsonCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/EncodeJsonCats.scala
@@ -1,8 +1,8 @@
 package argonaut
 
 import Argonaut._
-import cats._, data._
-import cats.functor.Contravariant
+import cats._, data._, functor._
+import std.list._
 
 object EncodeJsonCats extends EncodeJsonCatss {
 }

--- a/argonaut-cats/src/main/scala/argonaut/EncodeJsonCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/EncodeJsonCats.scala
@@ -1,0 +1,34 @@
+package argonaut
+
+import Argonaut._
+import cats._, data._, std.all._
+import cats.functor.Contravariant
+
+object EncodeJsonCats extends EncodeJsonCatss {
+}
+
+trait EncodeJsonCatss {
+  def fromFoldable[F[_], A](implicit A: EncodeJson[A], F: Foldable[F]): EncodeJson[F[A]] =
+    EncodeJson(fa => jArray(F.foldLeft(fa, Nil: List[Json])((list, a) => A.encode(a) :: list).reverse))
+
+  implicit def DisjunctionEncodeJson[A, B](implicit ea: EncodeJson[A], eb: EncodeJson[B]): EncodeJson[Xor[A, B]] =
+    EncodeJson(_.fold(
+      a => jSingleObject("Left", ea(a)),
+      b => jSingleObject("Right", eb(b))
+    ))
+
+  implicit val EncodeJsonContra: Contravariant[EncodeJson] = new Contravariant[EncodeJson] {
+    def contramap[A, B](r: EncodeJson[A])(f: B => A) = r contramap f
+  }
+
+  implicit def NonEmptyListEncodeJson[A: EncodeJson]: EncodeJson[NonEmptyList[A]] =
+    fromFoldable[NonEmptyList, A]
+
+  implicit def StreamingEncodeJson[A: EncodeJson]: EncodeJson[Streaming[A]] =
+    fromFoldable[Streaming, A]
+
+  implicit def ValidationEncodeJson[E, A](implicit ea: EncodeJson[E], eb: EncodeJson[A]): EncodeJson[Validated[E, A]] =
+    EncodeJson(_ fold (
+      e => jSingleObject("Invalid", ea(e)), a => jSingleObject("Valid", eb(a))
+    ))
+}

--- a/argonaut-cats/src/main/scala/argonaut/EncodeJsonCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/EncodeJsonCats.scala
@@ -21,14 +21,14 @@ trait EncodeJsonCatss {
   implicit def StreamingEncodeJson[A: EncodeJson]: EncodeJson[Streaming[A]] =
     fromFoldable[Streaming, A]
 
-  implicit def ValidatedEncodeJson[E, A](implicit ea: EncodeJson[E], eb: EncodeJson[A]): EncodeJson[Validated[E, A]] =
+  implicit def ValidatedEncodeJson[E, A](implicit EA: EncodeJson[E], EB: EncodeJson[A]): EncodeJson[Validated[E, A]] =
     EncodeJson(_ fold (
-      e => jSingleObject("Invalid", ea(e)), a => jSingleObject("Valid", eb(a))
+      e => jSingleObject("Invalid", EA(e)), a => jSingleObject("Valid", EB(a))
     ))
 
-  implicit def XorEncodeJson[A, B](implicit ea: EncodeJson[A], eb: EncodeJson[B]): EncodeJson[Xor[A, B]] =
+  implicit def XorEncodeJson[A, B](implicit EA: EncodeJson[A], EB: EncodeJson[B]): EncodeJson[Xor[A, B]] =
     EncodeJson(_.fold(
-      a => jSingleObject("Left", ea(a)),
-      b => jSingleObject("Right", eb(b))
+      a => jSingleObject("Left", EA(a)),
+      b => jSingleObject("Right", EB(b))
     ))
 }

--- a/argonaut-cats/src/main/scala/argonaut/EncodeJsonCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/EncodeJsonCats.scala
@@ -1,7 +1,7 @@
 package argonaut
 
 import Argonaut._
-import cats._, data._, std.all._
+import cats._, data._
 import cats.functor.Contravariant
 
 object EncodeJsonCats extends EncodeJsonCatss {

--- a/argonaut-cats/src/main/scala/argonaut/HCursorCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/HCursorCats.scala
@@ -1,0 +1,6 @@
+package argonaut
+
+object HCursorCats extends HCursorCatss
+
+trait HCursorCatss {
+}

--- a/argonaut-cats/src/main/scala/argonaut/JsonCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/JsonCats.scala
@@ -1,6 +1,10 @@
 package argonaut
 
+import JsonNumberCats._
+import JsonObjectCats._
 import cats._
+import std.list._
+import syntax.eq._
 
 object JsonCats extends JsonCatss {
 }
@@ -11,11 +15,11 @@ trait JsonCatss {
       def eqv(a1: Json, a2: Json) = {
         a1 match {
           case JNull => a2.isNull
-          case JBool(b) => a2.bool contains b
-          case JNumber(n) => a2.number contains n
-          case JString(s) => a2.string contains s
-          case JArray(a) => a2.array contains a
-          case JObject(o) => a2.obj contains o
+          case JBool(b) => a2.bool exists (_ == b)
+          case JNumber(n) => a2.number exists (_ === n)
+          case JString(s) => a2.string exists (_ == s)
+          case JArray(a) => a2.array exists (_ === a)
+          case JObject(o) => a2.obj exists (_ === o)
         }
       }
 

--- a/argonaut-cats/src/main/scala/argonaut/JsonCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/JsonCats.scala
@@ -6,7 +6,6 @@ object JsonCats extends JsonCatss {
 }
 
 trait JsonCatss {
-
   implicit val JsonInstances: Eq[Json] with Show[Json] = {
     new Eq[Json] with Show[Json] {
       def eqv(a1: Json, a2: Json) = {

--- a/argonaut-cats/src/main/scala/argonaut/JsonCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/JsonCats.scala
@@ -1,0 +1,26 @@
+package argonaut
+
+import cats._
+
+object JsonCats extends JsonCatss {
+}
+
+trait JsonCatss {
+
+  implicit val JsonInstances: Eq[Json] with Show[Json] = {
+    new Eq[Json] with Show[Json] {
+      def eqv(a1: Json, a2: Json) = {
+        a1 match {
+          case JNull => a2.isNull
+          case JBool(b) => a2.bool contains b
+          case JNumber(n) => a2.number contains n
+          case JString(s) => a2.string contains s
+          case JArray(a) => a2.array contains a
+          case JObject(o) => a2.obj contains o
+        }
+      }
+
+      override def show(a: Json): String = Show.fromToString.show(a)
+    }
+  }
+}

--- a/argonaut-cats/src/main/scala/argonaut/JsonIdentityCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/JsonIdentityCats.scala
@@ -1,0 +1,6 @@
+package argonaut
+
+object JsonIdentityCats extends JsonIdentityCatss
+
+trait JsonIdentityCatss {
+}

--- a/argonaut-cats/src/main/scala/argonaut/JsonNumberCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/JsonNumberCats.scala
@@ -1,0 +1,9 @@
+package argonaut
+
+import cats._
+
+object JsonNumberCats {
+  implicit val JsonNumberEq: Eq[JsonNumber] = new Eq[JsonNumber] {
+    def eqv(a: JsonNumber, b: JsonNumber) = a == b
+  }
+}

--- a/argonaut-cats/src/main/scala/argonaut/JsonObjectCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/JsonObjectCats.scala
@@ -2,7 +2,8 @@ package argonaut
 
 import Json._
 import JsonObject._
-import cats._, syntax.foldable._
+import cats._
+import syntax.foldable._
 
 object JsonObjectCats extends JsonObjectCatss {
   def from[F[_]: Foldable](f: F[(JsonField, Json)]): JsonObject = {

--- a/argonaut-cats/src/main/scala/argonaut/JsonObjectCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/JsonObjectCats.scala
@@ -1,0 +1,18 @@
+package argonaut
+
+import argonaut.Json._
+import argonaut.JsonObject._
+import cats._
+import cats.syntax.foldable._
+
+object JsonObjectCats extends JsonObjectCatss {
+  def from[F[_]: Foldable](f: F[(JsonField, Json)]): JsonObject = {
+    f.foldLeft(empty) { case (acc, (k, v)) => acc + (k, v) }
+  }
+}
+
+trait JsonObjectCatss {
+  implicit val JsonObjectShow = Show.fromToString[JsonObject]
+
+  implicit val JsonObjectEqual = Eq.fromUniversalEquals[JsonObject]
+}

--- a/argonaut-cats/src/main/scala/argonaut/JsonObjectCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/JsonObjectCats.scala
@@ -1,9 +1,8 @@
 package argonaut
 
-import argonaut.Json._
-import argonaut.JsonObject._
-import cats._
-import cats.syntax.foldable._
+import Json._
+import JsonObject._
+import cats._, syntax.foldable._
 
 object JsonObjectCats extends JsonObjectCatss {
   def from[F[_]: Foldable](f: F[(JsonField, Json)]): JsonObject = {
@@ -12,7 +11,7 @@ object JsonObjectCats extends JsonObjectCatss {
 }
 
 trait JsonObjectCatss {
-  implicit val JsonObjectShow = Show.fromToString[JsonObject]
+  implicit val JsonObjectEq = Eq.fromUniversalEquals[JsonObject]
 
-  implicit val JsonObjectEqual = Eq.fromUniversalEquals[JsonObject]
+  implicit val JsonObjectShow = Show.fromToString[JsonObject]
 }

--- a/argonaut-cats/src/main/scala/argonaut/JsonObjectCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/JsonObjectCats.scala
@@ -3,7 +3,7 @@ package argonaut
 import Json._
 import JsonObject._
 import cats._
-import syntax.foldable._
+import syntax.foldable._, syntax.functor._
 
 object JsonObjectCats extends JsonObjectCatss {
   def from[F[_]: Foldable](f: F[(JsonField, Json)]): JsonObject = {
@@ -15,4 +15,13 @@ trait JsonObjectCatss {
   implicit val JsonObjectEq = Eq.fromUniversalEquals[JsonObject]
 
   implicit val JsonObjectShow = Show.fromToString[JsonObject]
+
+  def traverse[F[_]](o: JsonObject, f: Json => F[Json])(implicit FF: Applicative[F]): F[JsonObject] = {
+    o.toList.foldLeft(FF.pure(List[JsonAssoc]())){case (acc, (k, v)) =>
+      FF.map2(acc, f(v)){(elems, newV) =>
+        (k, newV) :: elems
+      }
+    }.map(elems => JsonObject.fromTraversableOnce(elems.reverse))
+  }
+
 }

--- a/argonaut-cats/src/main/scala/argonaut/PrettyParamsCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/PrettyParamsCats.scala
@@ -5,5 +5,5 @@ import cats._
 object PrettyParamsCats extends PrettyParamsCatss
 
 trait PrettyParamsCatss {
-  implicit val prettyParamsEq: Eq[PrettyParams] = Eq.fromUniversalEquals
+  implicit val PrettyParamsEq: Eq[PrettyParams] = Eq.fromUniversalEquals
 }

--- a/argonaut-cats/src/main/scala/argonaut/PrettyParamsCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/PrettyParamsCats.scala
@@ -1,0 +1,9 @@
+package argonaut
+
+import cats._
+
+object PrettyParamsCats extends PrettyParamsCatss
+
+trait PrettyParamsCatss {
+  implicit val prettyParamsEq: Eq[PrettyParams] = Eq.fromUniversalEquals
+}

--- a/argonaut-cats/src/main/scala/argonaut/StringWrapCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/StringWrapCats.scala
@@ -1,0 +1,6 @@
+package argonaut
+
+object StringWrapCats extends StringWrapCatss
+
+trait StringWrapCatss {
+}

--- a/argonaut-cats/src/test/scala/argonaut/CursorHistoryCatsSpecification.scala
+++ b/argonaut-cats/src/test/scala/argonaut/CursorHistoryCatsSpecification.scala
@@ -1,0 +1,14 @@
+package argonaut
+
+import algebra.laws.GroupLaws
+import arbitrary._
+import org.specs2.Specification
+import org.typelevel.discipline.specs2.Discipline
+
+/**
+  * Created by luissanchez on 27/01/2016.
+  */
+class CursorHistoryCatsSpecification extends Specification with Discipline with CursorHistoryCatss { def is =
+  br ^ br ^
+  checkAll("CursorHistory", GroupLaws[CursorHistory].monoid)
+}

--- a/argonaut-cats/src/test/scala/argonaut/CursorHistoryCatsSpecification.scala
+++ b/argonaut-cats/src/test/scala/argonaut/CursorHistoryCatsSpecification.scala
@@ -2,13 +2,14 @@ package argonaut
 
 import algebra.laws.GroupLaws
 import arbitrary._
+import CursorHistoryCats._
 import org.specs2.Specification
 import org.typelevel.discipline.specs2.Discipline
 
 /**
   * Created by luissanchez on 27/01/2016.
   */
-class CursorHistoryCatsSpecification extends Specification with Discipline with CursorHistoryCatss { def is =
+class CursorHistoryCatsSpecification extends Specification with Discipline { def is =
   br ^ br ^
   checkAll("CursorHistory", GroupLaws[CursorHistory].monoid)
 }

--- a/argonaut-cats/src/test/scala/argonaut/DecodeResultCatsSpecification.scala
+++ b/argonaut-cats/src/test/scala/argonaut/DecodeResultCatsSpecification.scala
@@ -1,0 +1,24 @@
+package argonaut
+
+import arbitrary._
+import CursorHistoryCats._
+import DecodeResultCats._
+import cats.std.all._
+import cats.laws.discipline.MonadTests
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.specs2.Specification
+import org.typelevel.discipline.specs2.Discipline
+
+/**
+  * Created by luissanchez on 27/01/2016.
+  */
+class DecodeResultCatsSpecification extends Specification with Discipline {
+
+  implicit val NumGen: Gen[Int] = Gen.posNum[Int]
+  implicit val FunGen: Gen[Int => Int] = arbFunction1[Int, Int].arbitrary
+
+  def is =
+    br ^ br ^
+    checkAll("DecodeResult[Int]", MonadTests[DecodeResult].monad[Int, Int, Int])
+}

--- a/argonaut-cats/src/test/scala/argonaut/EncodeJsonCatsSpecification.scala
+++ b/argonaut-cats/src/test/scala/argonaut/EncodeJsonCatsSpecification.scala
@@ -1,0 +1,33 @@
+package argonaut
+
+import org.scalacheck._
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Prop._
+import org.specs2.{ScalaCheck, Specification}
+
+/**
+  * Created by luissanchez on 27/01/2016.
+  */
+class EncodeJsonCatsSpecification extends Specification with ScalaCheck {
+
+  def is =s2"""
+  contravariants laws must hold for EncodeJson[Int]
+    contravariant identity    ${contravariantIdentity}
+    contravariant composition ${contravariantcomposition}
+  """.stripMargin
+
+  def contravariantIdentity = forAll(Gen.posNum[Int]) { a =>
+      val left = EncodeJson.IntEncodeJson.contramap(identity[Int])
+      val right = EncodeJson.IntEncodeJson
+
+      left.encode(a) must_== right.encode(a)
+  }
+
+  def contravariantcomposition = forAll(Gen.posNum[Int], arbFunction1[Int, Int].arbitrary, arbFunction1[Int, Int].arbitrary) {
+    (a, f, g) =>
+    val left = EncodeJson.IntEncodeJson.contramap(f).contramap(g)
+    val right = EncodeJson.IntEncodeJson.contramap(f compose g)
+
+    left.encode(a) must_== right.encode(a)
+  }
+}

--- a/argonaut-cats/src/test/scala/argonaut/JsonObjectCatsSpecification.scala
+++ b/argonaut-cats/src/test/scala/argonaut/JsonObjectCatsSpecification.scala
@@ -1,0 +1,13 @@
+package argonaut
+
+import argonaut.Data._
+import argonaut.JsonObjectCats._
+import cats.syntax.show._
+import org.specs2._
+
+object JsonObjectCatsSpecification extends Specification with ScalaCheck {
+  def is = s2"""
+  JsonObjectCats
+    shows  ${prop((o: JsonObject) => o.show === o.toString)}
+   """
+}

--- a/argonaut-cats/src/test/scala/argonaut/arbitrary.scala
+++ b/argonaut-cats/src/test/scala/argonaut/arbitrary.scala
@@ -1,0 +1,45 @@
+package argonaut
+
+import org.scalacheck._
+import org.scalacheck.Gen._
+
+/**
+  * Created by luissanchez on 27/01/2016.
+  */
+object arbitrary {
+
+  // Some CursorOpElement
+  val cursorOpElementCursorOpLeft: Gen[CursorOpElement] = Gen.const(CursorOpLeft)
+  val cursorOpElementCursorOpRight: Gen[CursorOpElement] = Gen.const(CursorOpRight)
+  val cursorOpElementCursorOpFirst: Gen[CursorOpElement] = Gen.const(CursorOpFirst)
+  val cursorOpElementCursorOpLast: Gen[CursorOpElement] = Gen.const(CursorOpLast)
+  val cursorOpElementCursorOpUp: Gen[CursorOpElement] = Gen.const(CursorOpUp)
+
+  implicit val cursorOpElementGen: Gen[CursorOpElement] = Gen.oneOf(
+    cursorOpElementCursorOpLeft,
+    cursorOpElementCursorOpRight,
+    cursorOpElementCursorOpFirst,
+    cursorOpElementCursorOpLast,
+    cursorOpElementCursorOpUp
+  )
+  // CursorOp
+  def cursorOpEl(implicit F: Gen[CursorOpElement]): Gen[CursorOp] = zip(F, Gen.oneOf(true, false)).map((El.apply _).tupled)
+
+  val cursorOpReattempt: Gen[CursorOp] = Gen.const(Reattempt)
+
+  implicit val cursorOpsGen: Gen[CursorOp] = Gen.oneOf(cursorOpEl, cursorOpReattempt)
+
+  implicit val cursorHistoryGen: Gen[CursorHistory] = Gen.listOf(cursorOpsGen).map(CursorHistory(_))
+
+  implicit val cursorHistoryArb: Arbitrary[CursorHistory] = Arbitrary(cursorHistoryGen)
+
+  implicit def decodeResultGen[A](implicit GenA: Gen[A]): Gen[DecodeResult[A]] =
+      for {
+        string <- alphaStr
+        cursorHistory <- cursorHistoryGen
+        a <- GenA
+        generated <- Gen.oneOf(Left((string, cursorHistory)), Right(a))
+      } yield DecodeResult(generated)
+
+  implicit def decodeResultArb[A](implicit GenA: Gen[A]): Arbitrary[DecodeResult[A]] = Arbitrary(decodeResultGen(GenA))
+}

--- a/project/build.scala
+++ b/project/build.scala
@@ -28,6 +28,8 @@ object build extends Build {
   val monocleMacro               = "com.github.julien-truffaut"   %% "monocle-macro"             % monocleVersion
   val monocleLaw                 = "com.github.julien-truffaut"   %% "monocle-law"               % monocleVersion           % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
   val cats                       = "org.spire-math"               %% "cats"                      % catsVersion
+  val catsLaw                    = "org.spire-math"               %% "cats-laws"                 % catsVersion              % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
+  val catsTests                  = "org.spire-math"               %% "cats-tests"                % catsVersion              % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
 
   def reflect(v: String)         =
                                     Seq("org.scala-lang" % "scala-reflect"  % v) ++
@@ -109,6 +111,7 @@ object build extends Build {
       name := "argonaut-cats"
       , libraryDependencies ++= Seq(
         cats
+        , catsLaw
         , scalacheck
         , specs2Scalacheck
       )
@@ -135,5 +138,5 @@ object build extends Build {
     , fork in run := true
     , publishArtifact := false
     )
-  ).aggregate(argonaut, argonautScalaz, argonautMonocle, argonautBenchmark)
+  ).aggregate(argonaut, argonautScalaz, argonautMonocle, argonautCats, argonautBenchmark)
 }

--- a/project/build.scala
+++ b/project/build.scala
@@ -16,6 +16,7 @@ object build extends Build {
   val scalazVersion              = "7.2.0"
   val paradiseVersion            = "2.1.0-M5"
   val monocleVersion             = "1.3.0-SNAPSHOT"
+  val catsVersion                = "0.3.0"
   val scalaz                     = "org.scalaz"                   %% "scalaz-core"               % scalazVersion
   val scalazScalaCheckBinding    = "org.scalaz"                   %% "scalaz-scalacheck-binding" % scalazVersion            % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
   val scalacheck                 = "org.scalacheck"               %% "scalacheck"                % "1.11.4"                 % "test"
@@ -26,6 +27,7 @@ object build extends Build {
   val monocle                    = "com.github.julien-truffaut"   %% "monocle-core"              % monocleVersion
   val monocleMacro               = "com.github.julien-truffaut"   %% "monocle-macro"             % monocleVersion
   val monocleLaw                 = "com.github.julien-truffaut"   %% "monocle-law"               % monocleVersion           % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
+  val cats                       = "org.spire-math"               %% "cats"                      % catsVersion
 
   def reflect(v: String)         =
                                     Seq("org.scala-lang" % "scala-reflect"  % v) ++
@@ -99,6 +101,19 @@ object build extends Build {
       )
     )
   ).dependsOn(argonaut % "compile->compile;test->test", argonautScalaz % "compile->compile;test->test")
+
+  val argonautCats = Project(
+    id = "argonaut-cats"
+    , base = file("argonaut-cats")
+    , settings = commonSettings ++ Seq(
+      name := "argonaut-cats"
+      , libraryDependencies ++= Seq(
+        cats
+        , scalacheck
+        , specs2Scalacheck
+      )
+    )
+  ).dependsOn(argonaut % "compile->compile;test->test")
 
   val argonautBenchmark = Project(
     id = "argonaut-benchmark"


### PR DESCRIPTION
With the new modular approach, an `argonaut-cats` module can be easily added. This is still a WIP but I would like @seanparsons to review it before continuing. 
As `cats` has no lenses support, this module has less features than the `scalaz` module.