### PR TITLE
* update cats to version 0.4.0 and create a cats extension package to place Tuple2 and Tuple3 instances

### DIFF
--- a/argonaut-cats/src/main/scala/argonaut/DecodeResultCats.scala
+++ b/argonaut-cats/src/main/scala/argonaut/DecodeResultCats.scala
@@ -2,15 +2,15 @@ package argonaut
 
 import CursorHistoryCats._
 import cats._, data._
+import ext.std.tuple._
 import std.either._, std.string._
-import syntax.contravariant._, syntax.eq._, syntax.show._
+import syntax.contravariant._
 
 object DecodeResultCats extends DecodeResultCatss {
 }
 
 trait DecodeResultCatss {
-  import TupleInstances._
-  
+
   @annotation.tailrec
   final def loop[A, X](d: DecodeResult[A], e: (String, CursorHistory) => X, f: A => Xor[X, DecodeResult[A]]): X = {
     if (d.isError) {
@@ -36,17 +36,4 @@ trait DecodeResultCatss {
 
   implicit def DecodeResultShow[A](implicit SE: Show[DecodeEither[A]]): Show[DecodeResult[A]] =
     SE.contramap(_.toEither)
-}
-
-private object TupleInstances extends TupleInstances0
-
-private trait TupleInstances0 {
-
-  implicit def Tuple2Eq[A, B](implicit EA: Eq[A], EB: Eq[B]): Eq[(A, B)] = new Eq[(A, B)] {
-    override def eqv(x: (A, B), y: (A, B)): Boolean = x._1 === y._1 && x._2 === y._2
-  }
-
-  implicit def Tuple2Show[A, B](implicit SA: Show[A], SB: Show[B]): Show[(A, B)] = new Show[(A, B)] {
-    override def show(f: (A, B)): String = "(" + f._1.show + ", " + f._2.show + "}"
-  }
 }

--- a/argonaut-cats/src/main/scala/cats/ext/std/tuple.scala
+++ b/argonaut-cats/src/main/scala/cats/ext/std/tuple.scala
@@ -1,0 +1,29 @@
+package cats.ext.std
+
+import cats._
+import cats.syntax.eq._
+import cats.syntax.show._
+
+/**
+  * Created by luissanchez on 03/02/2016.
+  */
+trait TupleInstances {
+
+  implicit def Tuple2Eq[A, B](implicit EA: Eq[A], EB: Eq[B]): Eq[(A, B)] = new Eq[(A, B)] {
+    override def eqv(x: (A, B), y: (A, B)): Boolean = x._1 === y._1 && x._2 === y._2
+  }
+
+  implicit def Tuple2Show[A, B](implicit SA: Show[A], SB: Show[B]): Show[(A, B)] = new Show[(A, B)] {
+    override def show(f: (A, B)): String = "(" + f._1.show + ", " + f._2.show + "}"
+  }
+
+  implicit def Tuple3Eq[A, B, C](implicit EA: Eq[A], EB: Eq[B], EC: Eq[C]): Eq[(A, B, C)] = new Eq[(A, B, C)] {
+    override def eqv(x: (A, B, C), y: (A, B, C)): Boolean = x._1 === y._1 && x._2 === y._2 && x._3 === y._3
+  }
+
+  implicit def Tuple3Show[A, B, C](implicit SA: Show[A], SB: Show[B], SC: Show[C]): Show[(A, B, C)] = new Show[(A, B, C)] {
+    override def show(f: (A, B, C)): String = "(" + f._1.show + ", " + f._2.show + ", " + f._3.show + "}"
+  }
+}
+
+object tuple extends TupleInstances

--- a/argonaut-cats/src/test/scala/argonaut/DecodeResultCatsSpecification.scala
+++ b/argonaut-cats/src/test/scala/argonaut/DecodeResultCatsSpecification.scala
@@ -1,9 +1,10 @@
 package argonaut
 
 import arbitrary._
-import CursorHistoryCats._
 import DecodeResultCats._
+import cats.ext.std.tuple
 import cats.std.all._
+import tuple._
 import cats.laws.discipline.MonadTests
 import org.scalacheck._
 import org.scalacheck.Arbitrary._

--- a/project/build.scala
+++ b/project/build.scala
@@ -16,7 +16,7 @@ object build extends Build {
   val scalazVersion              = "7.2.0"
   val paradiseVersion            = "2.1.0-M5"
   val monocleVersion             = "1.3.0-SNAPSHOT"
-  val catsVersion                = "0.3.0"
+  val catsVersion                = "0.4.0"
   val scalaz                     = "org.scalaz"                   %% "scalaz-core"               % scalazVersion
   val scalazScalaCheckBinding    = "org.scalaz"                   %% "scalaz-scalacheck-binding" % scalazVersion            % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
   val scalacheck                 = "org.scalacheck"               %% "scalacheck"                % "1.11.4"                 % "test"
@@ -27,9 +27,9 @@ object build extends Build {
   val monocle                    = "com.github.julien-truffaut"   %% "monocle-core"              % monocleVersion
   val monocleMacro               = "com.github.julien-truffaut"   %% "monocle-macro"             % monocleVersion
   val monocleLaw                 = "com.github.julien-truffaut"   %% "monocle-law"               % monocleVersion           % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
-  val cats                       = "org.spire-math"               %% "cats"                      % catsVersion
-  val catsLaw                    = "org.spire-math"               %% "cats-laws"                 % catsVersion              % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
-  val catsTests                  = "org.spire-math"               %% "cats-tests"                % catsVersion              % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
+  val cats                       = "org.typelevel"                %% "cats"                      % catsVersion
+  val catsLaw                    = "org.typelevel"                %% "cats-laws"                 % catsVersion              % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
+  val catsTests                  = "org.typelevel"                %% "cats-tests"                % catsVersion              % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
 
   def reflect(v: String)         =
                                     Seq("org.scala-lang" % "scala-reflect"  % v) ++


### PR DESCRIPTION
Cats 0.4.0 has been released. As I needed to add an `Eq` instances for `Tuple3` to make the tests work again,  I have created a cats extension package inside argonaut. This package would go away once cats adds instances for all tuples.

@seanparsons I can move the instances to a different package if current one goes against any design principle :)