### PR TITLE
Add jawn support.

### DIFF
--- a/argonaut-jawn/src/main/scala/argonaut/JawnParser.scala
+++ b/argonaut-jawn/src/main/scala/argonaut/JawnParser.scala
@@ -1,0 +1,43 @@
+package argonaut
+
+import scala.collection.mutable
+import jawn.{Facade, FContext, SupportParser}
+
+object JawnParser extends SupportParser[Json] {
+  implicit val facade: Facade[Json] =
+    new Facade[Json] {
+      def jnull() = Json.jNull
+      def jfalse() = Json.jFalse
+      def jtrue() = Json.jTrue
+      def jnum(s: String) = Json.jNumber(JsonNumber.unsafeDecimal(s))
+      def jint(s: String) = Json.jNumber(JsonNumber.unsafeDecimal(s))
+      def jstring(s: String) = Json.jString(s)
+
+      def singleContext() = new FContext[Json] {
+        var value: Json = null
+        def add(s: String) { value = jstring(s) }
+        def add(v: Json) { value = v }
+        def finish: Json = value
+        def isObj: Boolean = false
+      }
+
+      def arrayContext() = new FContext[Json] {
+        val vs = mutable.ListBuffer.empty[Json]
+        def add(s: String) { vs += jstring(s) }
+        def add(v: Json) { vs += v }
+        def finish: Json = Json.jArray(vs.toList)
+        def isObj: Boolean = false
+      }
+
+      def objectContext() = new FContext[Json] {
+        var key: String = null
+        var vs = JsonObject.empty
+        def add(s: String): Unit =
+          if (key == null) { key = s } else { vs = vs + (key, jstring(s)); key = null }
+        def add(v: Json): Unit =
+        { vs = vs + (key, v); key = null }
+        def finish = Json.jObject(vs)
+        def isObj = true
+      }
+    }
+}

--- a/argonaut-jawn/src/test/scala/argonaut/JawnParserSpecification.scala
+++ b/argonaut-jawn/src/test/scala/argonaut/JawnParserSpecification.scala
@@ -22,7 +22,7 @@ object JawnParserSpecification {
 }
 
 class JawnParserSpecification extends Specification with ScalaCheck {
-  import ParserSpec._
+  import JawnParserSpecification._
   import JawnParser.facade
 
   def is = s2"""

--- a/argonaut-jawn/src/test/scala/argonaut/JawnParserSpecification.scala
+++ b/argonaut-jawn/src/test/scala/argonaut/JawnParserSpecification.scala
@@ -1,0 +1,42 @@
+package argonaut
+
+import scala.util.Try
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.specs2._
+import Argonaut._
+
+object JawnParserSpecification {
+  case class Example(a: Int, b: Long, c: Double)
+
+  val exampleCodecJson: CodecJson[Example] =
+    casecodec3(Example.apply, Example.unapply)("a", "b", "c")
+
+  implicit val exampleCaseClassArbitrary: Arbitrary[Example] = Arbitrary(
+    for {
+      a <- arbitrary[Int]
+      b <- arbitrary[Long]
+      c <- arbitrary[Double]
+    } yield Example(a, b, c)
+  )
+}
+
+class JawnParserSpecification extends Specification with ScalaCheck {
+  import ParserSpec._
+  import JawnParser.facade
+
+  def is = s2"""
+  The JawnParser
+    correctly marshal case classes with Long values           $marshal
+  """
+
+  def marshal =
+    prop { (e: Example) =>
+      val jsonString: String = exampleCodecJson.encode(e).nospaces
+      val json: Try[Json] = jawn.Parser.parseFromString(jsonString)
+      exampleCodecJson.decodeJson(json.get).toOption match {
+        case None => ko("did not parse")
+        case Some(example) => example must_== e
+      }
+    }
+}

--- a/project/build.scala
+++ b/project/build.scala
@@ -24,6 +24,7 @@ object build extends Build {
   val caliper                    = "com.google.caliper"           %  "caliper"                   % "0.5-rc1"
   val liftjson                   = "net.liftweb"                  %% "lift-json"                 % "2.6-RC1"
   val jackson                    = "com.fasterxml.jackson.core"   %  "jackson-core"              % "2.4.1.1"
+  val jawnParser                 = "org.spire-math"               %% "jawn-parser"               % "0.8.4"
   val monocle                    = "com.github.julien-truffaut"   %% "monocle-core"              % monocleVersion
   val monocleMacro               = "com.github.julien-truffaut"   %% "monocle-macro"             % monocleVersion
   val monocleLaw                 = "com.github.julien-truffaut"   %% "monocle-law"               % monocleVersion           % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
@@ -118,6 +119,17 @@ object build extends Build {
     )
   ).dependsOn(argonaut % "compile->compile;test->test")
 
+  val argonautJawn = Project(
+    id = "argonaut-jawn"
+  , base = file("argonaut-jawn")
+  , settings = commonSettings ++ Seq[Sett](
+      name := "argonaut-jawn"
+    , libraryDependencies ++= Seq(
+        jawnParser
+      )
+    )
+  ).dependsOn(argonaut % "compile->compile;test->test")
+
   val argonautBenchmark = Project(
     id = "argonaut-benchmark"
   , base = file("argonaut-benchmark")
@@ -138,5 +150,11 @@ object build extends Build {
     , fork in run := true
     , publishArtifact := false
     )
-  ).aggregate(argonaut, argonautScalaz, argonautMonocle, argonautCats, argonautBenchmark)
+  ).aggregate(
+    argonaut
+  , argonautScalaz
+  , argonautMonocle
+  , argonautCats
+  , argonautJawn
+  , argonautBenchmark)
 }


### PR DESCRIPTION
This is a direct copy of jawn-argonaut's parser and a translation of
its spec into Argonaut's test stack.

See #218, non/jawn#49.