### PR TITLE
Remove sbt-dependency-graph plugin

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -42,7 +42,7 @@ object build extends Build {
     PublishSettings.all ++
     InfoSettings.all ++
     Seq(addCompilerPlugin("org.scalamacros" % "paradise" % paradiseVersion cross CrossVersion.full)) ++
-    net.virtualvoid.sbt.graph.Plugin.graphSettings ++ Seq[Sett](
+    Seq[Sett](
       scalacOptions += "-language:_"
     , (sourceGenerators in Compile) <+= (sourceManaged in Compile) map Boilerplate.gen
     , resolvers += Resolver.sonatypeRepo("releases")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,3 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.2")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.6")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.7.4")


### PR DESCRIPTION
It's really more of a developer utility plugin that should be installed by individual developer instead of imposed by the project. Not that it is a bad plugin, quite the contrary!