### PR TITLE
Scalaz 7.2 support for 6.1.x

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -13,13 +13,13 @@ object build extends Build {
       organization := "io.argonaut"
   )
 
-  val scalazVersion              = "7.1.1"
+  val scalazVersion              = "7.2.2"
   val paradiseVersion            = "2.0.1"
-  val monocleVersion             = "1.1.0"
+  val monocleVersion             = "1.2.1"
   val scalaz                     = "org.scalaz"                   %% "scalaz-core"               % scalazVersion
   val scalazScalaCheckBinding    = "org.scalaz"                   %% "scalaz-scalacheck-binding" % scalazVersion            % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
   val scalacheck                 = "org.scalacheck"               %% "scalacheck"                % "1.11.4"                 % "test"
-  val specs2Scalacheck           = "org.specs2"                   %% "specs2-scalacheck"         % "2.4.1"                  % "test"
+  val specs2Scalacheck           = "org.specs2"                   %% "specs2-scalacheck"         % "3.6.6-scalaz-7.2.0"     % "test"
   val caliper                    = "com.google.caliper"           %  "caliper"                   % "0.5-rc1"
   val liftjson                   = "net.liftweb"                  %% "lift-json"                 % "2.6-RC1"
   val jackson                    = "com.fasterxml.jackson.core"   %  "jackson-core"              % "2.4.1.1"

--- a/src/main/scala/argonaut/Json.scala
+++ b/src/main/scala/argonaut/Json.scala
@@ -1,6 +1,6 @@
 package argonaut
 
-import scalaz.{Each => _, Index => _, _}, Scalaz._
+import scalaz._, Scalaz._
 import scalaz.syntax.std.option._
 
 /**
@@ -809,7 +809,7 @@ trait Jsons {
     }
   }
 
-  implicit val jObjectAt = new At[JsonObject, JsonField, Json]{
+  implicit val jObjectAt = new At[JsonObject, JsonField, Option[Json]]{
     def at(field: JsonField): Lens[JsonObject, Option[Json]] =
       monocle.Lens[JsonObject, Option[Json]](_.apply(field))( optVal => jObj =>
         optVal.fold(jObj - field)(value => jObj + (field, value))

--- a/src/test/scala/argonaut/CodecSpecification.scala
+++ b/src/test/scala/argonaut/CodecSpecification.scala
@@ -46,7 +46,7 @@ object CodecSpecification extends Specification with ScalaCheck {
     Vector[String] encode/decode ${encodedecode[Vector[String]]}
     Stream[String] encode/decode ${encodedecode[Stream[String]]}
     SortedSet[String] encode/decode ${encodedecode[SortedSet[String]]}
-    SortedSet[Int] encode/decode ${encodedecode[SortedSet[Int]].pendingUntilFixed("ScalaCheck is not helping")}
+    SortedSet[Int] encode/decode ${encodedecode[SortedSet[Int]]}
     Array[String] encode/decode ${encodedecode[Array[String]]}
     ArrayBuffer[String] encode/decode ${encodedecode[ArrayBuffer[String]]}
     String encode/decode ${encodedecode[String]}

--- a/src/test/scala/argonaut/JsonFilesSpecification.scala
+++ b/src/test/scala/argonaut/JsonFilesSpecification.scala
@@ -17,12 +17,12 @@ object JsonFilesSpecification extends Specification with ScalaCheck {
 
   def is = s2""" Predefined files can print and get same result" ! $test """
 
-  def test = propNoShrink{(jsonfile: JsonFile) =>
+  def test = prop{(jsonfile: JsonFile) =>
     val string = scala.io.Source.fromFile(jsonfile.file).mkString
     val parsed = string.parseOption
     val json = parsed.getOrElse(sys.error("could not parse json file [" + jsonfile + "]"))
     json.nospaces.parseOption must beSome(json)
     json.spaces2.parseOption must beSome(json)
     json.spaces4.parseOption must beSome(json)
-  }
+  }.noShrink
 }

--- a/src/test/scala/argonaut/JsonOpticsSpecification.scala
+++ b/src/test/scala/argonaut/JsonOpticsSpecification.scala
@@ -1,7 +1,7 @@
 package argonaut
 
 import argonaut.Data._
-import monocle.law.PrismLaws
+import monocle.law.discipline.PrismTests
 import org.specs2.{ScalaCheck, Specification}
 
 import scalaz.std.string._
@@ -13,19 +13,19 @@ object JsonOpticsSpecification extends Specification with ScalaCheck {
 
   def is = s2"""
   Prism
-    JsonBoolean     ${PrismLaws(Json.jBoolPrism)}
-    JsonNumber      ${PrismLaws(Json.jNumberPrism)}
-    JsonArray       ${PrismLaws(Json.jArrayPrism)}
-    JsonObject      ${PrismLaws(Json.jObjectPrism)}
+    JsonBoolean     ${PrismTests(Json.jBoolPrism).all}
+    JsonNumber      ${PrismTests(Json.jNumberPrism).all}
+    JsonArray       ${PrismTests(Json.jArrayPrism).all}
+    JsonObject      ${PrismTests(Json.jObjectPrism).all}
 
-    JsonBigDecimal  ${PrismLaws(Json.jBigDecimalPrism)}
-    JsonDouble      ${PrismLaws(Json.jDoublePrism)}
-    JsonFloat       ${PrismLaws(Json.jDoublePrism)}
-    JsonBigInt      ${PrismLaws(Json.jBigIntPrism)}
-    JsonLong        ${PrismLaws(Json.jLongPrism)}
-    JsonInt         ${PrismLaws(Json.jIntPrism)}
-    JsonShort       ${PrismLaws(Json.jShortPrism)}
-    JsonByte        ${PrismLaws(Json.jBytePrism)}
+    JsonBigDecimal  ${PrismTests(Json.jBigDecimalPrism).all}
+    JsonDouble      ${PrismTests(Json.jDoublePrism).all}
+    JsonFloat       ${PrismTests(Json.jDoublePrism).all}
+    JsonBigInt      ${PrismTests(Json.jBigIntPrism).all}
+    JsonLong        ${PrismTests(Json.jLongPrism).all}
+    JsonInt         ${PrismTests(Json.jIntPrism).all}
+    JsonShort       ${PrismTests(Json.jShortPrism).all}
+    JsonByte        ${PrismTests(Json.jBytePrism).all}
   """
-  
+
 }

--- a/src/test/scala/argonaut/PrettyParamsSpecification.scala
+++ b/src/test/scala/argonaut/PrettyParamsSpecification.scala
@@ -14,7 +14,7 @@ import scalaz._
 import Scalaz._
 import scalaz.scalacheck.ScalazProperties._
 import scalaz.scalacheck.ScalazArbitrary._
-import monocle.law.LensLaws
+import monocle.law.discipline.LensTests
 
 object PrettyParamsSpecification extends Specification with ScalaCheck {
   // Synthetic Equal implementations used for testing.
@@ -114,23 +114,23 @@ object PrettyParamsSpecification extends Specification with ScalaCheck {
     null keys are not present when last key is null    ${noNullKeys.lastKeyNull}
   """
 
-  def lbraceLeftLens = LensLaws(PrettyParams.lbraceLeftL)
-  def lbraceRightLens = LensLaws(PrettyParams.lbraceRightL)
-  def rbraceLeftLens = LensLaws(PrettyParams.rbraceLeftL)
-  def rbraceRightLens = LensLaws(PrettyParams.rbraceRightL)
-  def lbracketLeftLens = LensLaws(PrettyParams.lbracketLeftL)
-  def lbracketRightLens = LensLaws(PrettyParams.lbracketRightL)
-  def rbracketLeftLens = LensLaws(PrettyParams.rbracketLeftL)
-  def rbracketRightLens = LensLaws(PrettyParams.rbracketRightL)
-  def lrbracketsEmptyLens = LensLaws(PrettyParams.lrbracketsEmptyL)
-  def arrayCommaLeftLens = LensLaws(PrettyParams.arrayCommaLeftL)
-  def arrayCommaRightLens = LensLaws(PrettyParams.arrayCommaRightL)
-  def objectCommaLeftLens = LensLaws(PrettyParams.objectCommaLeftL)
-  def objectCommaRightLens = LensLaws(PrettyParams.objectCommaRightL)
-  def colonLeftLens = LensLaws(PrettyParams.colonLeftL)
-  def colonRightLens = LensLaws(PrettyParams.colonRightL)
-  def preserveOrderLens = LensLaws(PrettyParams.preserveOrderL)
-  def dropNullKeysLens = LensLaws(PrettyParams.dropNullKeysL)
+  def lbraceLeftLens = LensTests(PrettyParams.lbraceLeftL).all
+  def lbraceRightLens = LensTests(PrettyParams.lbraceRightL).all
+  def rbraceLeftLens = LensTests(PrettyParams.rbraceLeftL).all
+  def rbraceRightLens = LensTests(PrettyParams.rbraceRightL).all
+  def lbracketLeftLens = LensTests(PrettyParams.lbracketLeftL).all
+  def lbracketRightLens = LensTests(PrettyParams.lbracketRightL).all
+  def rbracketLeftLens = LensTests(PrettyParams.rbracketLeftL).all
+  def rbracketRightLens = LensTests(PrettyParams.rbracketRightL).all
+  def lrbracketsEmptyLens = LensTests(PrettyParams.lrbracketsEmptyL).all
+  def arrayCommaLeftLens = LensTests(PrettyParams.arrayCommaLeftL).all
+  def arrayCommaRightLens = LensTests(PrettyParams.arrayCommaRightL).all
+  def objectCommaLeftLens = LensTests(PrettyParams.objectCommaLeftL).all
+  def objectCommaRightLens = LensTests(PrettyParams.objectCommaRightL).all
+  def colonLeftLens = LensTests(PrettyParams.colonLeftL).all
+  def colonRightLens = LensTests(PrettyParams.colonRightL).all
+  def preserveOrderLens = LensTests(PrettyParams.preserveOrderL).all
+  def dropNullKeysLens = LensTests(PrettyParams.dropNullKeysL).all
 
   def lbraceLeftIndent = prop{(indent: String) =>
     val prettyParams = PrettyParams.nospace.copy(lbraceLeft = indent)


### PR DESCRIPTION
Scalaz 7.2 is currently supported for 6.2-M1. However there's a significant difference between 6.1 and 6.2 such that upgrading isn't trivial. So here's an intermediary step providing 7.2 support for the 6.1 series.