### PR TITLE
fix Scala version checking logic to work with 2.12

### DIFF
--- a/argonaut/src/main/scala-2.12/argonaut.internal/MacrosCompat.scala
+++ b/argonaut/src/main/scala-2.12/argonaut.internal/MacrosCompat.scala
@@ -1,0 +1,13 @@
+package argonaut.internal
+
+trait MacrosCompat {
+  type Context = scala.reflect.macros.blackbox.Context
+
+  def getDeclarations(c: Context)(tpe: c.universe.Type): c.universe.MemberScope = tpe.decls
+
+  def getParameterLists(c: Context)(method: c.universe.MethodSymbol): List[List[c.universe.Symbol]] = method.paramLists
+
+  def getDeclaration(c: Context)(tpe: c.universe.Type, name: c.universe.Name): c.universe.Symbol = tpe.decl(name)
+
+  def createTermName(c: Context)(name: String): c.universe.TermName = c.universe.TermName(name)
+}

--- a/project/ScalaSettings.scala
+++ b/project/ScalaSettings.scala
@@ -11,6 +11,12 @@ object ScalaSettings {
     Nil
   )
 
+  def sourceDirectoryName(version: String): String =
+    CrossVersion.partialVersion(version) match {
+      case Some((major, minor)) =>
+        s"scala-$major.$minor"
+    }
+
   lazy val all: Seq[Sett] = Seq(
     scalaVersion := "2.11.8"
   , crossScalaVersions := Seq("2.10.6", "2.11.8")
@@ -19,8 +25,8 @@ object ScalaSettings {
   , scalacOptions ++= PartialFunction.condOpt(CrossVersion.partialVersion(scalaVersion.value)){
       case Some((2, v)) if v >= 11 => unusedWarnings
     }.toList.flatten
-  // https://gist.github.com/djspiewak/976cd8ac65e20e136f05
-  , unmanagedSourceDirectories in Compile += (sourceDirectory in Compile).value / s"scala-${scalaBinaryVersion.value}"
+  , unmanagedSourceDirectories in Compile +=
+      (sourceDirectory in Compile).value / sourceDirectoryName(scalaVersion.value)
   ) ++ Seq(Compile, Test).flatMap(c =>
     scalacOptions in (c, console) ~= {_.filterNot(unusedWarnings.toSet)}
   )


### PR DESCRIPTION
not using scalaBinaryVersion, either, because for e.g.
2.12.0-RC1 the scalaBinaryVersion is 2.12.0-RC1, not 2.12

this came up in the context of the Scala 2.12 community build.