### PR TITLE
upgrade monocle, scalaz and scalacheck

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -13,14 +13,14 @@ object build extends Build {
       organization := "io.argonaut"
   )
 
-  val scalazVersion              = "7.2.2"
+  val scalazVersion              = "7.2.6"
   val paradiseVersion            = "2.1.0"
-  val monocleVersion             = "1.2.2"
+  val monocleVersion             = "1.3.0"
   val catsVersion                = "0.7.2"
   val scalaz                     = "org.scalaz"                   %% "scalaz-core"               % scalazVersion
   val scalazScalaCheckBinding    = "org.scalaz"                   %% "scalaz-scalacheck-binding" % scalazVersion            % "test" exclude("org.scalacheck", "scalacheck_2.11") exclude("org.scalacheck", "scalacheck_2.10")
-  val scalacheck                 = "org.scalacheck"               %% "scalacheck"                % "1.12.5"                 % "test"
-  val specs2Scalacheck           = "org.specs2"                   %% "specs2-scalacheck"         % "3.6.6-scalaz-7.2.0"     % "test"
+  val scalacheck                 = "org.scalacheck"               %% "scalacheck"                % "1.13.2"                 % "test"
+  val specs2Scalacheck           = "org.specs2"                   %% "specs2-scalacheck"         % "3.8.5"                  % "test"
   val caliper                    = "com.google.caliper"           %  "caliper"                   % "0.5-rc1"
   val liftjson                   = "net.liftweb"                  %% "lift-json"                 % "2.6-RC1"
   val jackson                    = "com.fasterxml.jackson.core"   %  "jackson-core"              % "2.4.1.1"


### PR DESCRIPTION
I am not sure why I get the following with `cats` as  `scalacheck` is excluded:

```
[error] Could not run test argonaut.DecodeResultCatsSpecification: java.lang.NoSuchMethodError: org.scalacheck.Arbitrary$.arbFunction1(Lorg/scalacheck/Arbitrary;)Lorg/scalacheck/Arbitrary;
```