### PR TITLE
JsonFoldPath and unsafe optics

### DIFF
--- a/argonaut-monocle/src/main/scala/argonaut/JsonPath.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/JsonPath.scala
@@ -4,9 +4,10 @@ import argonaut.JsonMonocle._
 import argonaut.JsonObjectMonocle._
 import monocle.function.{At, FilterIndex, Index}
 import monocle.std.list._
-import monocle.{Optional, Traversal}
+import monocle.{Fold, Optional, Traversal}
 
 import scala.language.dynamics
+import scalaz.Monoid
 
 final case class JsonPath(json: Optional[Json, Json]) extends Dynamic {
   def `null`: Optional[Json, Unit] = json composePrism jNullPrism
@@ -23,22 +24,28 @@ final case class JsonPath(json: Optional[Json, Json]) extends Dynamic {
   def obj: Optional[Json, JsonObject] = json composePrism jObjectPrism
 
   def at(field: String): Optional[Json, Option[Json]] =
-    json.composePrism(jObjectPrism).composeLens(At.at(field))
+    json composePrism jObjectPrism composeLens At.at(field)
 
   def selectDynamic(field: String): JsonPath =
-    JsonPath(json.composePrism(jObjectPrism).composeOptional(Index.index(field)))
+    JsonPath(json composePrism jObjectPrism composeOptional Index.index(field))
 
   def index(i: Int): JsonPath =
-    JsonPath(json.composePrism(jArrayPrism).composeOptional(Index.index(i)))
+    JsonPath(json composePrism jArrayPrism composeOptional Index.index(i))
 
   def each: JsonTraversalPath =
     JsonTraversalPath(json composeTraversal jDescendants)
 
-  def arrFilter(p: Int => Boolean): JsonTraversalPath =
+  def filterByIndex(p: Int => Boolean): JsonTraversalPath =
     JsonTraversalPath(arr composeTraversal FilterIndex.filterIndex(p))
 
-  def objFilter(p: String => Boolean): JsonTraversalPath =
+  def filterByField(p: String => Boolean): JsonTraversalPath =
     JsonTraversalPath(obj composeTraversal FilterIndex.filterIndex(p))
+
+  final def filter(p: Json => Boolean): JsonFoldPath =
+    JsonFoldPath(json composeFold OpticsHelper.select(p))
+
+  final def as[A: DecodeJson]: Fold[Json, A] =
+    json composeFold OpticsHelper.parse
 }
 
 object JsonPath {
@@ -60,20 +67,81 @@ final case class JsonTraversalPath(json: Traversal[Json, Json]) extends Dynamic 
   def obj: Traversal[Json, JsonObject] = json composePrism jObjectPrism
 
   def at(field: String): Traversal[Json, Option[Json]] =
-    json.composePrism(jObjectPrism).composeLens(At.at(field))
+    json composePrism jObjectPrism composeLens At.at(field)
 
   def selectDynamic(field: String): JsonTraversalPath =
-    JsonTraversalPath(json.composePrism(jObjectPrism).composeOptional(Index.index(field)))
+    JsonTraversalPath(json composePrism jObjectPrism composeOptional Index.index(field))
 
   def index(i: Int): JsonTraversalPath =
-    JsonTraversalPath(json.composePrism(jArrayPrism).composeOptional(Index.index(i)))
+    JsonTraversalPath(json composePrism jArrayPrism composeOptional Index.index(i))
 
   def each: JsonTraversalPath =
     JsonTraversalPath(json composeTraversal jDescendants)
 
-  def arrFilter(p: Int => Boolean): JsonTraversalPath =
+  def filterByIndex(p: Int => Boolean): JsonTraversalPath =
     JsonTraversalPath(arr composeTraversal FilterIndex.filterIndex(p))
 
-  def objFilter(p: String => Boolean): JsonTraversalPath =
+  def filterByField(p: String => Boolean): JsonTraversalPath =
     JsonTraversalPath(obj composeTraversal FilterIndex.filterIndex(p))
+
+  final def filter(p: Json => Boolean): JsonFoldPath =
+    JsonFoldPath(json composeFold OpticsHelper.select(p))
+
+  final def as[A: DecodeJson]: Fold[Json, A] =
+    json composeFold OpticsHelper.parse
+}
+
+final case class JsonFoldPath(json: Fold[Json, Json]) extends Dynamic {
+  final def `null`: Fold[Json, Unit] = json composePrism jNullPrism
+  final def boolean: Fold[Json, Boolean] = json composePrism jBoolPrism
+  final def byte: Fold[Json, Byte] = json composePrism jBytePrism
+  final def short: Fold[Json, Short] = json composePrism jShortPrism
+  final def int: Fold[Json, Int] = json composePrism jIntPrism
+  final def long: Fold[Json, Long] = json composePrism jLongPrism
+  final def bigInt: Fold[Json, BigInt] = json composePrism jBigIntPrism
+  final def bigDecimal: Fold[Json, BigDecimal] = json composePrism jBigDecimalPrism
+  final def number: Fold[Json, JsonNumber] = json composePrism jNumberPrism
+  final def string: Fold[Json, String] = json composePrism jStringPrism
+  final def arr: Fold[Json, List[Json]] = json composePrism jArrayPrism
+  final def obj: Fold[Json, JsonObject] = json composePrism jObjectPrism
+
+  final def at(field: String): Fold[Json, Option[Json]] =
+    json composePrism jObjectPrism composeLens At.at(field)
+
+  final def selectDynamic(field: String): JsonFoldPath =
+    JsonFoldPath(json composePrism jObjectPrism composeOptional Index.index(field))
+
+  final def index(i: Int): JsonFoldPath =
+    JsonFoldPath(json composePrism jArrayPrism composeOptional Index.index(i))
+
+  final def each: JsonFoldPath =
+    JsonFoldPath(json composeTraversal jDescendants)
+
+  final def filterByIndex(p: Int => Boolean): JsonFoldPath =
+    JsonFoldPath(arr composeTraversal FilterIndex.filterIndex(p))
+
+  final def filterByField(p: String => Boolean): JsonFoldPath =
+    JsonFoldPath(obj composeTraversal FilterIndex.filterIndex(p))
+
+  final def filter(p: Json => Boolean): JsonFoldPath =
+    JsonFoldPath(json composeFold OpticsHelper.select(p))
+
+  final def as[A: DecodeJson]: Fold[Json, A] =
+    json composeFold OpticsHelper.parse
+}
+
+object OpticsHelper {
+  /** Decode a value at the current location */
+  def parse[A](implicit decode: DecodeJson[A]): Fold[Json, A] =
+    new Fold[Json, A] {
+      def foldMap[M](f: A => M)(json: Json)(implicit ev: Monoid[M]): M =
+        decode.decodeJson(json).fold((_,_) => ev.zero, f)
+    }
+
+  /** Select if a value matches a predicate */
+  def select[A](p: A => Boolean): Fold[A, A] =
+    new Fold[A, A] {
+      def foldMap[M](f: A => M)(a: A)(implicit ev: Monoid[M]): M =
+        if(p(a)) f(a) else ev.zero
+    }
 }


### PR DESCRIPTION
- add JsonFoldPath and `filter`
- add `unsaferFilter`, `unsafeAs` 
- rename `arrFilter` to `filterByIndex` and `objFilter` to and `filterByField`

I am not sure we want to add `unsaferFilter`, `unsafeAs` as they are unlawful but they are quite convenient. If you prefer I will remove them from the PR.