### PR TITLE
Make truncateToBigInt fail when there would be too many digits

### DIFF
--- a/argonaut/src/main/scala/argonaut/DecodeJson.scala
+++ b/argonaut/src/main/scala/argonaut/DecodeJson.scala
@@ -277,7 +277,7 @@ trait DecodeJsons extends GeneratedDecodeJsons {
 
   implicit def BigIntDecodeJson: DecodeJson[BigInt] = {
     optionDecoder(x =>
-      (x.number map (_.truncateToBigInt)).orElse(
+      (x.number flatMap (_.truncateToBigInt)).orElse(
       (x.string flatMap (s => tryTo(BigInt(s))))), "BigInt")
   }
 

--- a/argonaut/src/main/scala/argonaut/JsonNumber.scala
+++ b/argonaut/src/main/scala/argonaut/JsonNumber.scala
@@ -94,8 +94,17 @@ sealed abstract class JsonNumber {
   /**
    * Truncates the number to a BigInt. Truncation means that we round the real
    * number towards 0 to the closest BigInt.
+   *
+   * Truncation fails for numbers whose decimal representation contains more
+   * than 2 ^ 18 digits, since creating `BigInt` values for these numbers is
+   * computationally expensive.
    */
-  def truncateToBigInt: BigInt = toBigDecimal.toBigInt
+  def truncateToBigInt: Option[BigInt] = {
+    val asBigDecimal = toBigDecimal
+    val digits = asBigDecimal.underlying.unscaledValue.abs.toString.length.toLong - asBigDecimal.scale.toLong
+
+    if (digits <= (1 << 18)) Some(asBigDecimal.toBigInt) else None
+  }
 
   /**
    * Truncates the number to a Long. Truncation means that we round the real

--- a/argonaut/src/test/scala/argonaut/JsonNumberSpecification.scala
+++ b/argonaut/src/test/scala/argonaut/JsonNumberSpecification.scala
@@ -18,6 +18,9 @@ object JsonNumberSpecification extends Specification with ScalaCheck {
 
     equals should
       Equivalent numbers are equal.             $equivalentNumbersAreEqual
+
+    truncateToBigInt should
+      Fail on numbers with too many digits.     $failOnLargeDecimalRepresentation
   """
 
   def longValuesProduceLongs = prop { (value: Long) =>
@@ -61,5 +64,10 @@ object JsonNumberSpecification extends Specification with ScalaCheck {
     JsonNumber.fromString("1E") must beNone
     JsonNumber.fromString("1E+") must beNone
     JsonNumber.fromString("1E-") must beNone
+  }
+
+  def failOnLargeDecimalRepresentation = {
+    JsonNumber.fromString("1e262144").map(_.truncateToBigInt) must_== Some(None)
+    JsonNumber.fromString("-1e262144").map(_.truncateToBigInt) must_== Some(None)
   }
 }


### PR DESCRIPTION
This is a quick attempt to fix #211 without more major changes to the way numbers are represented (which is the route I went in circe).

This is a breaking change, since the signature of `truncateToBig` needs to reflect the fact that it can fail, but given that #211 is a security liability for library users who are decoding into `BigInt`, this seems reasonable.