### PR TITLE
Use applyDynamic in JsonPaths to allow more terse array indexing

### DIFF
--- a/argonaut-monocle/src/main/scala/argonaut/JsonPath.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/JsonPath.scala
@@ -29,6 +29,8 @@ final case class JsonPath(json: Optional[Json, Json]) extends Dynamic {
   def selectDynamic(field: String): JsonPath =
     JsonPath(json composePrism jObjectPrism composeOptional Index.index(field))
 
+  def applyDynamic(field: String)(i: Int): JsonPath = selectDynamic(field).index(i)
+
   def index(i: Int): JsonPath =
     JsonPath(json composePrism jArrayPrism composeOptional Index.index(i))
 
@@ -72,6 +74,8 @@ final case class JsonTraversalPath(json: Traversal[Json, Json]) extends Dynamic 
   def selectDynamic(field: String): JsonTraversalPath =
     JsonTraversalPath(json composePrism jObjectPrism composeOptional Index.index(field))
 
+  def applyDynamic(field: String)(i: Int): JsonTraversalPath = selectDynamic(field).index(i)
+
   def index(i: Int): JsonTraversalPath =
     JsonTraversalPath(json composePrism jArrayPrism composeOptional Index.index(i))
 
@@ -110,6 +114,8 @@ final case class JsonFoldPath(json: Fold[Json, Json]) extends Dynamic {
 
   final def selectDynamic(field: String): JsonFoldPath =
     JsonFoldPath(json composePrism jObjectPrism composeOptional Index.index(field))
+
+  final def applyDynamic(field: String)(i: Int): JsonFoldPath = selectDynamic(field).index(i)
 
   final def index(i: Int): JsonFoldPath =
     JsonFoldPath(json composePrism jArrayPrism composeOptional Index.index(i))

--- a/argonaut-monocle/src/main/scala/argonaut/JsonPath.scala
+++ b/argonaut-monocle/src/main/scala/argonaut/JsonPath.scala
@@ -31,6 +31,8 @@ final case class JsonPath(json: Optional[Json, Json]) extends Dynamic {
 
   def applyDynamic(field: String)(i: Int): JsonPath = selectDynamic(field).index(i)
 
+  def apply(i: Int): JsonPath = index(i)
+
   def index(i: Int): JsonPath =
     JsonPath(json composePrism jArrayPrism composeOptional Index.index(i))
 
@@ -76,6 +78,8 @@ final case class JsonTraversalPath(json: Traversal[Json, Json]) extends Dynamic 
 
   def applyDynamic(field: String)(i: Int): JsonTraversalPath = selectDynamic(field).index(i)
 
+  def apply(i: Int): JsonTraversalPath = index(i)
+
   def index(i: Int): JsonTraversalPath =
     JsonTraversalPath(json composePrism jArrayPrism composeOptional Index.index(i))
 
@@ -116,6 +120,8 @@ final case class JsonFoldPath(json: Fold[Json, Json]) extends Dynamic {
     JsonFoldPath(json composePrism jObjectPrism composeOptional Index.index(field))
 
   final def applyDynamic(field: String)(i: Int): JsonFoldPath = selectDynamic(field).index(i)
+
+  final def apply(i: Int): JsonFoldPath = index(i)
 
   final def index(i: Int): JsonFoldPath =
     JsonFoldPath(json composePrism jArrayPrism composeOptional Index.index(i))

--- a/argonaut-monocle/src/test/scala/argonaut/JsonPathSpecification.scala
+++ b/argonaut-monocle/src/test/scala/argonaut/JsonPathSpecification.scala
@@ -46,6 +46,11 @@ object JsonPathSpecification extends Specification {
       root.cars(1).model.string.getOption(john) must_== Some("suv")
     }
 
+    "support traversal by array index using apply on the root" >> {
+      val jsonArray = Json.array("first".asJson, "second".asJson).asJson
+      root(0).string.getOption(jsonArray) must_== Some("first")
+    }
+
     "support insertion and deletion" >> {
       root.at("first_name").setOption(None)(john) must_== john.obj.map(_.-("first_name")).map(jObject)
       root.at("foo").set(Some(true.asJson))(john).obj.flatMap(_.apply("foo")) must_== Some(jTrue)

--- a/argonaut-monocle/src/test/scala/argonaut/JsonPathSpecification.scala
+++ b/argonaut-monocle/src/test/scala/argonaut/JsonPathSpecification.scala
@@ -42,6 +42,10 @@ object JsonPathSpecification extends Specification {
       root.cars.index(1).model.string.getOption(john) must_== Some("suv")
     }
 
+    "support traversal by array index using apply" >> {
+      root.cars(1).model.string.getOption(john) must_== Some("suv")
+    }
+
     "support insertion and deletion" >> {
       root.at("first_name").setOption(None)(john) must_== john.obj.map(_.-("first_name")).map(jObject)
       root.at("foo").set(Some(true.asJson))(john).obj.flatMap(_.apply("foo")) must_== Some(jTrue)


### PR DESCRIPTION
We can use `applyDynamic` to allow simple array indexing. Given the following JSON

```json
{
  "array": [0, 1, 2, 3, 4]
}
```

this change allows us to access an element of `array` like this: `root.array(1)` rather than like this: `root.array.index(1)`

I could only find a relevant test for `JsonPath` and not for `JsonFoldPath` and `JsonTraversalPath` which I found a little worrying. Have I missed something somewhere?