### PR TITLE
remove oraclejdk7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ notifications:
       - "\x0313argonaut\x03/\x0306%{branch}\x03 \x0314%{commit}\x03 %{build_url} %{message}"
 matrix:
   include:
-    - jdk: oraclejdk7
-      scala: 2.10.6
-      script: sbt ++${TRAVIS_SCALA_VERSION} test
     - jdk: openjdk7
       scala: 2.10.6
       script: sbt ++${TRAVIS_SCALA_VERSION} test
@@ -19,9 +16,6 @@ matrix:
       scala: 2.10.6
       script: sbt ++${TRAVIS_SCALA_VERSION} test
 
-    - jdk: oraclejdk7
-      scala: 2.11.11
-      script: sbt ++${TRAVIS_SCALA_VERSION} test:compile jvmParent/test # scala-js test unstable with java7
     - jdk: openjdk7
       scala: 2.11.11
       script: sbt ++${TRAVIS_SCALA_VERSION} test:compile jvmParent/test # scala-js test unstable with java7


### PR DESCRIPTION
travis-ci no longer support oraclejdk7

- https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879
- http://www.webupd8.org/2017/06/why-oracle-java-7-and-6-installers-no.html