### PR TITLE
fix unused warning scalacOptions

### DIFF
--- a/project/ScalaSettings.scala
+++ b/project/ScalaSettings.scala
@@ -8,7 +8,6 @@ object ScalaSettings {
 
   private[this] val unusedWarnings = (
     "-Ywarn-unused" ::
-    "-Ywarn-unused-import" ::
     Nil
   )
 


### PR DESCRIPTION
"-Ywarn-unused-import" deleted since Scala 2.13

https://github.com/scala/scala/commit/ad25805de5c630843