### PR TITLE
update dependencies. drop Scala 2.10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,6 @@ notifications:
 matrix:
   include:
     - jdk: openjdk7
-      scala: 2.10.7
-      script: sbt ++${TRAVIS_SCALA_VERSION} test
-    - jdk: oraclejdk8
-      scala: 2.10.7
-      script: sbt ++${TRAVIS_SCALA_VERSION} test
-
-    - jdk: openjdk7
       scala: 2.11.12
       script: sbt ++${TRAVIS_SCALA_VERSION} test:compile jvmParent/test # scala-js test unstable with java7
     - jdk: oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -27,15 +27,7 @@ val argonautScalaz = argonautCrossProject(
     )
   )
 ).platformsSettings(JVMPlatform, JSPlatform)(
-  libraryDependencies += {
-    val v = CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 10)) =>
-        s"${scalazVersion}-scalacheck-1.13"
-      case _ =>
-        s"${scalazVersion}-scalacheck-1.14"
-    }
-    "org.scalaz" %%% "scalaz-scalacheck-binding" % v % "test"
-  }
+  libraryDependencies += "org.scalaz" %%% "scalaz-scalacheck-binding" % s"${scalazVersion}-scalacheck-1.14" % "test"
 ).dependsOn(argonaut % "compile->compile;test->test")
 
 val argonautScalazJVM = argonautScalaz.jvm

--- a/project/ScalaSettings.scala
+++ b/project/ScalaSettings.scala
@@ -15,7 +15,7 @@ object ScalaSettings {
 
   lazy val all: Seq[Sett] = Def.settings(
     scalaVersion := Scala211
-  , crossScalaVersions := Seq("2.10.7", Scala211, "2.12.6")
+  , crossScalaVersions := Seq(Scala211, "2.12.6")
   , ensimeScalaVersion := Scala211
   , fork in test := true
   , scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature", "-language:_", "-Xlint", "-Xfuture")


### PR DESCRIPTION
I think it's time to drop Scala 2.10.x support because specs2, monocle and cats already dropped Scala 2.10.x support.