### PR TITLE
WIP Upgrade to jawn 1.0.0

### DIFF
--- a/argonaut-jawn/shared/src/main/scala/argonaut/JawnParser.scala
+++ b/argonaut-jawn/shared/src/main/scala/argonaut/JawnParser.scala
@@ -5,14 +5,14 @@ import org.typelevel.jawn.{Facade, FContext, SupportParser}
 
 object JawnParser extends SupportParser[Json] {
   implicit val facade: Facade[Json] =
-    new Facade[Json] {
-      def jnull() = Json.jNull
-      def jfalse() = Json.jFalse
-      def jtrue() = Json.jTrue
+    new Facade.NoIndexFacade[Json] {
+      def jnull = Json.jNull
+      def jfalse = Json.jFalse
+      def jtrue = Json.jTrue
       def jnum(s: CharSequence, decIndex: Int, expIndex: Int) = Json.jNumber(JsonNumber.unsafeDecimal(s.toString))
       def jstring(s: CharSequence) = Json.jString(s.toString)
 
-      def singleContext() = new FContext[Json] {
+      def singleContext() = new FContext.NoIndexFContext[Json] {
         var value: Json = null
         def add(s: CharSequence) = { value = jstring(s.toString) }
         def add(v: Json) = { value = v }
@@ -20,7 +20,7 @@ object JawnParser extends SupportParser[Json] {
         def isObj: Boolean = false
       }
 
-      def arrayContext() = new FContext[Json] {
+      def arrayContext() = new FContext.NoIndexFContext[Json] {
         val vs = mutable.ListBuffer.empty[Json]
         def add(s: CharSequence) = { vs += jstring(s.toString) }
         def add(v: Json) = { vs += v }
@@ -28,7 +28,7 @@ object JawnParser extends SupportParser[Json] {
         def isObj: Boolean = false
       }
 
-      def objectContext() = new FContext[Json] {
+      def objectContext() = new FContext.NoIndexFContext[Json] {
         var key: String = null
         var vs = JsonObject.empty
         def add(s: CharSequence): Unit =

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ val argonautJawn = argonautCrossProject(
   commonSettings ++ Seq(
     name := "argonaut-jawn"
   , libraryDependencies ++= Seq(
-      "org.typelevel"               %%%  "jawn-parser"               % "0.14.3"
+      "org.typelevel"               %%%  "jawn-parser"               % "1.0.0"
     )
   )
 ).dependsOn(argonaut % "compile->compile;test->test")


### PR DESCRIPTION
`jawn` has dropped support for scala 2.11 in `1.0.0` so the builds targeting 2.11 are expected to fail.